### PR TITLE
Switch to new timeout and flash macros

### DIFF
--- a/uwp5/soc/load_fw.c
+++ b/uwp5/soc/load_fw.c
@@ -169,7 +169,7 @@ int cp_check_running(void)
 		if (value & (1 << CP_RUNNING_BIT)) {
 			return 0;
 		}
-		k_sleep(30);
+		k_sleep(K_MSEC(30));
 	} while (cnt-- > 0);
 
 	return -1;
@@ -205,7 +205,7 @@ static void cp_sram_init(void)
 	val = sys_read32(0x40130004); /* enable */
 	val |= 0x220;
 	sys_write32(val, 0x40130004);
-	k_sleep(50);
+	k_sleep(K_MSEC(50));
 
 	val = sys_read32(0x4083c088); /* power on WRAP */
 	val &= ~(0x2);

--- a/uwp5/soc/load_fw.c
+++ b/uwp5/soc/load_fw.c
@@ -8,6 +8,7 @@
 LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 #include <zephyr.h>
+#include <storage/flash_map.h>
 #include <string.h>
 #include <uwp_hal.h>
 
@@ -27,8 +28,8 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 #define CP_START_ADDR_OFFSET	16
 
 #define CP_START_ADDR_CONTAINER	0x0200D000
-#define CP_START_MODEM0_ADDR	(0x02000000 + DT_FLASH_AREA_MODEM_0_OFFSET)
-#define CP_START_MODEM1_ADDR	(0x02000000 + DT_FLASH_AREA_MODEM_1_OFFSET)
+#define CP_START_MODEM0_ADDR	(0x02000000 + FLASH_AREA_OFFSET(modem_0))
+#define CP_START_MODEM1_ADDR	(0x02000000 + FLASH_AREA_OFFSET(modem_1))
 
 extern void GNSS_Start(void);
 


### PR DESCRIPTION
1. There are couple of k_sleep() calls which needs to be converted to
new timeout API. Let's do that now.
2. The old DT_FLASH macros are deprecated, hence switch to new macros
available in storage/flash_map.h.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>