### PR TITLE
Switch to standard definitions for integer types

### DIFF
--- a/uwp5/drivers/include/hal_aon_glb.h
+++ b/uwp5/drivers/include/hal_aon_glb.h
@@ -149,15 +149,15 @@ extern "C" {
 		CLK_416M   = 0x0,
 	} CLK_ARM_SEL_E;
 
-	static inline void uwp_aon_enable(u32_t bits) {
+	static inline void uwp_aon_enable(uint32_t bits) {
 		sci_glb_set(REG_AON_GLB_EB, bits);
 	}
 
-	static inline void uwp_aon_disable(u32_t bits) {
+	static inline void uwp_aon_disable(uint32_t bits) {
 		sci_glb_clr(REG_AON_GLB_EB, bits);
 	}
 
-	static inline void uwp_aon_reset(u32_t bits) {
+	static inline void uwp_aon_reset(uint32_t bits) {
 		int i = 50;
 
 		sci_glb_set(REG_AON_RST, bits);

--- a/uwp5/drivers/include/hal_base.h
+++ b/uwp5/drivers/include/hal_base.h
@@ -49,14 +49,14 @@ extern "C" {
 #define __REG_SET_ADDR(reg)		(reg + 0x1000)
 #define __REG_CLR_ADDR(reg)		(reg + 0x2000)
 
-__ramfunc static u32_t sci_read32(mem_addr_t addr)
+__ramfunc static uint32_t sci_read32(mem_addr_t addr)
 {
-	return *(volatile u32_t *)addr;
+	return *(volatile uint32_t *)addr;
 }
 
-__ramfunc static void sci_write32(mem_addr_t addr, u32_t data)
+__ramfunc static void sci_write32(mem_addr_t addr, uint32_t data)
 {
-	*(volatile u32_t *)addr = data;
+	*(volatile uint32_t *)addr = data;
 }
 
 #define sci_reg_and(reg, val) \

--- a/uwp5/drivers/include/hal_eic.h
+++ b/uwp5/drivers/include/hal_eic.h
@@ -30,35 +30,35 @@ extern "C" {
 
 #define EIC_MAX_NUM				(3)
 
-	static u32_t eic_base[3] = {
+	static uint32_t eic_base[3] = {
 		BASE_EIC0,
 		BASE_EIC1,
 		BASE_AON_EIC0,
 	};
 
-	static inline void uwp_hal_eic_enable(u32_t num, u32_t channel)
+	static inline void uwp_hal_eic_enable(uint32_t num, uint32_t channel)
 	{
 		sci_reg_or(eic_base[num] + EIC_LATCH_INTEN, BIT(channel));
 	}
 
-	static inline void uwp_hal_eic_disable(u32_t num, u32_t channel)
+	static inline void uwp_hal_eic_disable(uint32_t num, uint32_t channel)
 	{
 		sci_reg_and(eic_base[num] + EIC_LATCH_INTEN, ~BIT(channel));
 	}
 
-	static inline void uwp_hal_eic_enable_sleep(u32_t num, u32_t channel)
+	static inline void uwp_hal_eic_enable_sleep(uint32_t num, uint32_t channel)
 	{
 		sci_reg_and(eic_base[num] + EIC_LATCH_INTMODE, ~BIT(channel));
 	}
 
-	static inline void uwp_hal_eic_disable_sleep(u32_t num, u32_t channel)
+	static inline void uwp_hal_eic_disable_sleep(uint32_t num, uint32_t channel)
 	{
 		sci_reg_or(eic_base[num] + EIC_LATCH_INTMODE, BIT(channel));
 	}
 
-	static inline u32_t uwp_hal_eic_status(u32_t num, u32_t channel)
+	static inline uint32_t uwp_hal_eic_status(uint32_t num, uint32_t channel)
 	{
-		u32_t reg;
+		uint32_t reg;
 
 		//reg = sci_read32(REG_EIC0_LATCH_INTRAW);
 		reg = sci_read32(eic_base[num] + EIC_LATCH_INTMSK);
@@ -66,15 +66,15 @@ extern "C" {
 		return (reg >> channel) & 0x1;
 	}
 
-	static inline void uwp_hal_eic_clear(u32_t num, u32_t channel)
+	static inline void uwp_hal_eic_clear(uint32_t num, uint32_t channel)
 	{
 		sci_write32(eic_base[num] + EIC_LATCH_INTCLR, BIT(channel));
 	}
 
-	static inline void uwp_hal_eic_set_trigger(u32_t num,
-			u32_t channel, u32_t type)
+	static inline void uwp_hal_eic_set_trigger(uint32_t num,
+			uint32_t channel, uint32_t type)
 	{
-		u32_t reg;
+		uint32_t reg;
 
 		reg = sci_read32(eic_base[num] + EIC_LATCH_INTPOL);
 

--- a/uwp5/drivers/include/hal_gpio.h
+++ b/uwp5/drivers/include/hal_gpio.h
@@ -26,55 +26,55 @@ extern "C" {
 #define GPIO_TRIGGER_LOW_EDGE		5
 
 	struct uwp_gpio {
-		u32_t data;		/* data */
-		u32_t mask;		/* data mask */
-		u32_t dir;		/* data direction */
-		u32_t is;		/* interrupt sense */
-		u32_t ibe;		/* both edges interrup */
-		u32_t iev;		/* interrupt event */
-		u32_t ie;		/* interrupt enable */
-		u32_t ris;		/* raw interrupt status */
-		u32_t mis;		/* mask interrupt status */
-		u32_t ic;		/* interrupt clear */
-		u32_t inen;		/* input enable */
+		uint32_t data;		/* data */
+		uint32_t mask;		/* data mask */
+		uint32_t dir;		/* data direction */
+		uint32_t is;		/* interrupt sense */
+		uint32_t ibe;		/* both edges interrup */
+		uint32_t iev;		/* interrupt event */
+		uint32_t ie;		/* interrupt enable */
+		uint32_t ris;		/* raw interrupt status */
+		uint32_t mis;		/* mask interrupt status */
+		uint32_t ic;		/* interrupt clear */
+		uint32_t inen;		/* input enable */
 	};
 
 #define UWP_GPIO(base) (volatile struct uwp_gpio *)base
 
-	static inline void uwp_gpio_enable(u32_t base,
-			u32_t pin_map)
+	static inline void uwp_gpio_enable(uint32_t base,
+			uint32_t pin_map)
 	{
 		volatile struct uwp_gpio *gpio = UWP_GPIO(base);
 
 		gpio->mask |= pin_map;
 	}
 
-	static inline void uwp_gpio_disable(u32_t base,
-			u32_t pin_map)
+	static inline void uwp_gpio_disable(uint32_t base,
+			uint32_t pin_map)
 	{
 		volatile struct uwp_gpio *gpio = UWP_GPIO(base);
 
 		gpio->mask &= (~pin_map);
 	}
 
-	static inline void uwp_gpio_input_enable(u32_t base,
-			u32_t pin_map)
+	static inline void uwp_gpio_input_enable(uint32_t base,
+			uint32_t pin_map)
 	{
 		volatile struct uwp_gpio *gpio = UWP_GPIO(base);
 
 		gpio->inen |= pin_map;
 	}
 
-	static inline void uwp_gpio_input_disable(u32_t base,
-			u32_t pin_map)
+	static inline void uwp_gpio_input_disable(uint32_t base,
+			uint32_t pin_map)
 	{
 		volatile struct uwp_gpio *gpio = UWP_GPIO(base);
 
 		gpio->inen &= (~pin_map);
 	}
 
-	static inline void uwp_gpio_write(u32_t base,
-			u32_t pin_map, u32_t pin_value)
+	static inline void uwp_gpio_write(uint32_t base,
+			uint32_t pin_map, uint32_t pin_value)
 	{
 		volatile struct uwp_gpio *gpio = UWP_GPIO(base);
 
@@ -84,16 +84,16 @@ extern "C" {
 			gpio->data &= (~pin_map);
 	}
 
-	static inline u32_t uwp_gpio_read(u32_t base,
-			u32_t pin)
+	static inline uint32_t uwp_gpio_read(uint32_t base,
+			uint32_t pin)
 	{
 		volatile struct uwp_gpio *gpio = UWP_GPIO(base);
 
 		return (gpio->data & pin);
 	}
 
-	static inline void uwp_gpio_set_dir(u32_t base,
-			u32_t pin_map, u32_t dir)
+	static inline void uwp_gpio_set_dir(uint32_t base,
+			uint32_t pin_map, uint32_t dir)
 	{
 		volatile struct uwp_gpio *gpio = UWP_GPIO(base);
 
@@ -103,8 +103,8 @@ extern "C" {
 			gpio->dir &= (~pin_map);
 	}
 
-	static inline void uwp_gpio_int_set_type(u32_t base,
-			u32_t pin_map, u32_t type)
+	static inline void uwp_gpio_int_set_type(uint32_t base,
+			uint32_t pin_map, uint32_t type)
 	{
 		volatile struct uwp_gpio *gpio = UWP_GPIO(base);
 
@@ -131,31 +131,31 @@ extern "C" {
 
 	}
 
-	static inline void uwp_gpio_int_enable(u32_t base,
-			u32_t pin_map)
+	static inline void uwp_gpio_int_enable(uint32_t base,
+			uint32_t pin_map)
 	{
 		volatile struct uwp_gpio *gpio = UWP_GPIO(base);
 
 		gpio->ie |= pin_map;
 	}
 
-	static inline void uwp_gpio_int_disable(u32_t base,
-			u32_t pin_map)
+	static inline void uwp_gpio_int_disable(uint32_t base,
+			uint32_t pin_map)
 	{
 		volatile struct uwp_gpio *gpio = UWP_GPIO(base);
 
 		gpio->ie &= (~pin_map);
 	}
 
-	static inline void uwp_gpio_int_clear(u32_t base,
-			u32_t pin_map)
+	static inline void uwp_gpio_int_clear(uint32_t base,
+			uint32_t pin_map)
 	{
 		volatile struct uwp_gpio *gpio = UWP_GPIO(base);
 
 		gpio->ic |= pin_map;
 	}
 
-	static inline u32_t uwp_gpio_int_status(u32_t base, u32_t bmask)
+	static inline uint32_t uwp_gpio_int_status(uint32_t base, uint32_t bmask)
 	{
 		volatile struct uwp_gpio *gpio = UWP_GPIO(base);
 

--- a/uwp5/drivers/include/hal_intc.h
+++ b/uwp5/drivers/include/hal_intc.h
@@ -42,27 +42,27 @@ extern "C" {
 #define AON_INT_UART	12
 
 	struct uwp_intc {
-		u32_t mask_sts;
-		u32_t raw_sts;
-		u32_t enable;
-		u32_t disable;
-		u32_t irq_soft;
-		u32_t test_src;
-		u32_t test_sel;
-		u32_t reserved;
+		uint32_t mask_sts;
+		uint32_t raw_sts;
+		uint32_t enable;
+		uint32_t disable;
+		uint32_t irq_soft;
+		uint32_t test_src;
+		uint32_t test_sel;
+		uint32_t reserved;
 	};
 
-	static inline void uwp_intc_enable(volatile struct uwp_intc *intc, u32_t ch)
+	static inline void uwp_intc_enable(volatile struct uwp_intc *intc, uint32_t ch)
 	{
 		intc->enable |= BIT(ch);
 	}
 
-	static inline void uwp_intc_disable(volatile struct uwp_intc *intc, u32_t ch)
+	static inline void uwp_intc_disable(volatile struct uwp_intc *intc, uint32_t ch)
 	{
 		intc->disable |= BIT(ch);
 	}
 
-	static inline u32_t uwp_intc_status(volatile struct uwp_intc *intc)
+	static inline uint32_t uwp_intc_status(volatile struct uwp_intc *intc)
 	{
 		return intc->mask_sts;
 	}

--- a/uwp5/drivers/include/hal_pinmux.h
+++ b/uwp5/drivers/include/hal_pinmux.h
@@ -78,9 +78,9 @@ enum PINMUX_REG_UWP {
 	PCIE_WAKE_L,
 };
 
-static inline void __pin_enbable(u8_t enable)
+static inline void __pin_enbable(uint8_t enable)
 {
-	u32_t regval;
+	uint32_t regval;
 
 	regval  = sys_read32(REG_APB_EB);
 	if (enable) {
@@ -90,45 +90,45 @@ static inline void __pin_enbable(u8_t enable)
 	}
 }
 
-static inline void uwp_pmux_func_clear(u32_t pin)
+static inline void uwp_pmux_func_clear(uint32_t pin)
 {
-	u32_t pin_reg = PINMUX_PIN_REG(pin);
-	u32_t conf = sys_read32(pin_reg);
+	uint32_t pin_reg = PINMUX_PIN_REG(pin);
+	uint32_t conf = sys_read32(pin_reg);
 
 	conf &= (~(PMUX_PIN_FUNC(1)));
 	sys_write32(conf, pin_reg);
 }
 
-static inline void uwp_pmux_func_set(u32_t pin, u32_t func)
+static inline void uwp_pmux_func_set(uint32_t pin, uint32_t func)
 {
-	u32_t pin_reg = PINMUX_PIN_REG(pin);
-	u32_t conf = sys_read32(pin_reg);
+	uint32_t pin_reg = PINMUX_PIN_REG(pin);
+	uint32_t conf = sys_read32(pin_reg);
 
 	conf |= (PMUX_PIN_FUNC(func));
 	sys_write32(conf, pin_reg);
 }
 
-static inline void uwp_pmux_get(u32_t pin, u32_t *func)
+static inline void uwp_pmux_get(uint32_t pin, uint32_t *func)
 {
-	u32_t pin_reg = PINMUX_PIN_REG(pin);
-	u32_t conf = sys_read32(pin_reg);
+	uint32_t pin_reg = PINMUX_PIN_REG(pin);
+	uint32_t conf = sys_read32(pin_reg);
 
 	*func = conf;
 }
 
-static inline void uwp_pmux_pin_pullup(u32_t pin)
+static inline void uwp_pmux_pin_pullup(uint32_t pin)
 {
-	u32_t pin_reg = PINMUX_PIN_REG(pin);
-	u32_t conf = sys_read32(pin_reg);
+	uint32_t pin_reg = PINMUX_PIN_REG(pin);
+	uint32_t conf = sys_read32(pin_reg);
 
 	conf |= PIN_FPU_EN;
 	sys_write32(conf, pin_reg);
 }
 
-static inline void uwp_pmux_pin_pulldown(u32_t pin)
+static inline void uwp_pmux_pin_pulldown(uint32_t pin)
 {
-	u32_t pin_reg = PINMUX_PIN_REG(pin);
-	u32_t conf = sys_read32(pin_reg);
+	uint32_t pin_reg = PINMUX_PIN_REG(pin);
+	uint32_t conf = sys_read32(pin_reg);
 
 	conf |= PIN_FPD_EN;
 	sys_write32(conf, pin_reg);

--- a/uwp5/drivers/include/hal_pinmux_api.h
+++ b/uwp5/drivers/include/hal_pinmux_api.h
@@ -15,8 +15,8 @@ extern "C"
 #include "uwp_hal.h"
 
 struct pm_pinfunc_tag {
-	u32_t addr;
-	u32_t value;
+	uint32_t addr;
+	uint32_t value;
 };
 
 int uwp_pinmux_init(struct device *dev);

--- a/uwp5/drivers/include/hal_sfc.h
+++ b/uwp5/drivers/include/hal_sfc.h
@@ -12,48 +12,48 @@ extern "C" {
 #endif
 
 #include <zephyr/types.h>
-#include <arch/arm/exc.h>
+#include <arch/arm/aarch32/exc.h>
 #include <irq.h>
 
 #include "uwp_hal.h"
 
 	typedef struct SPIFLASH_ExtCfg {
 		int voltage;
-		u32_t desity;
-		u32_t reserved1;
-		u32_t reserved2;
-		u32_t reserved3;
-		u32_t reserved4;
-		u32_t reserved5;
+		uint32_t desity;
+		uint32_t reserved1;
+		uint32_t reserved2;
+		uint32_t reserved3;
+		uint32_t reserved4;
+		uint32_t reserved5;
 	} *Spiflash_ExtCfg_PRT;
 
 	typedef struct nor_flash_config_s {
-		u32_t bank_num;
-		u32_t sect_num;
-		u32_t file_sect_num;
-		u32_t sect_size;
-		u32_t start_addr;
-		u32_t efs_start_addr;
-		u32_t flash_size;
-		u32_t fixnv_addr;
-		u32_t prodinfo_addr;
-		u32_t mmi_res;
-		u32_t umem_addr;
-		u32_t umem_size;
-		u32_t spload_addr;
-		u32_t ps_addr;
+		uint32_t bank_num;
+		uint32_t sect_num;
+		uint32_t file_sect_num;
+		uint32_t sect_size;
+		uint32_t start_addr;
+		uint32_t efs_start_addr;
+		uint32_t flash_size;
+		uint32_t fixnv_addr;
+		uint32_t prodinfo_addr;
+		uint32_t mmi_res;
+		uint32_t umem_addr;
+		uint32_t umem_size;
+		uint32_t spload_addr;
+		uint32_t ps_addr;
 	} NOR_FLASH_CONFIG_T, *NOR_FLASH_CONFIG_PTR;
 
 	typedef struct DFILE_CONFIG_Tag {
-		u32_t magic_first;
-		u32_t magic_second;
-		u32_t image_addr;
-		u32_t res_addr;
-		u32_t nv_addr;
-		u32_t dsp_addr;
-		u32_t reserved2;
-		u32_t ext[24];
-		u32_t magic_end;
+		uint32_t magic_first;
+		uint32_t magic_second;
+		uint32_t image_addr;
+		uint32_t res_addr;
+		uint32_t nv_addr;
+		uint32_t dsp_addr;
+		uint32_t reserved2;
+		uint32_t ext[24];
+		uint32_t magic_end;
 	} DFILE_CONFIG_T;
 
 	struct spi_flash_region {
@@ -71,62 +71,62 @@ extern "C" {
 	} READ_CMD_TYPE_E;
 
 	struct spi_flash {
-		u32_t cs;
+		uint32_t cs;
 
 		const char *name;
-		u32_t size;
-		u32_t page_size;
-		u32_t sector_size;
-		u32_t dummy_bytes;
-		u8_t work_mode;
-		u8_t support_4addr;
+		uint32_t size;
+		uint32_t page_size;
+		uint32_t sector_size;
+		uint32_t dummy_bytes;
+		uint8_t work_mode;
+		uint8_t support_4addr;
 		int spi_rw_mode;
 
-		int (*read_noxip) (struct spi_flash * flash, u32_t address,
-				u8_t * buf, u32_t buf_size, READ_CMD_TYPE_E type);
-		int (*read) (struct spi_flash * flash, u32_t offset, u32_t * buf,
-				u32_t dump_len, READ_CMD_TYPE_E type);
-		int (*write) (struct spi_flash * flash, u32_t offset, u32_t len,
+		int (*read_noxip) (struct spi_flash * flash, uint32_t address,
+				uint8_t * buf, uint32_t buf_size, READ_CMD_TYPE_E type);
+		int (*read) (struct spi_flash * flash, uint32_t offset, uint32_t * buf,
+				uint32_t dump_len, READ_CMD_TYPE_E type);
+		int (*write) (struct spi_flash * flash, uint32_t offset, uint32_t len,
 				const void *buf);
-		int (*read_sec_noxip) (struct spi_flash * flash, u8_t * buf,
-				u32_t buf_size, READ_CMD_TYPE_E type);
-		int (*read_sec) (struct spi_flash * flash, u32_t offset, u32_t * buf,
-				u32_t dump_len, READ_CMD_TYPE_E type);
-		int (*write_sec) (struct spi_flash * flash, u32_t offset, u32_t len,
+		int (*read_sec_noxip) (struct spi_flash * flash, uint8_t * buf,
+				uint32_t buf_size, READ_CMD_TYPE_E type);
+		int (*read_sec) (struct spi_flash * flash, uint32_t offset, uint32_t * buf,
+				uint32_t dump_len, READ_CMD_TYPE_E type);
+		int (*write_sec) (struct spi_flash * flash, uint32_t offset, uint32_t len,
 				const void *buf);
-		int (*erase) (struct spi_flash * flash, u32_t offset, u32_t len);
+		int (*erase) (struct spi_flash * flash, uint32_t offset, uint32_t len);
 		int (*erase_chip) (struct spi_flash * flash);
 
 		int (*reset) (void);
 		int (*suspend) (struct spi_flash * flash);
 		int (*resume) (struct spi_flash * flash);
 		int (*wren)(struct spi_flash *flash);
-		int (*lock) (struct spi_flash * flash, u32_t offset, u32_t len);
-		int (*unlock) (struct spi_flash * flash, u32_t offset, u32_t len);
-		int (*set_4io) (struct spi_flash * flash, u32_t op);
-		int (*set_qpi) (struct spi_flash * flash, u32_t op);
+		int (*lock) (struct spi_flash * flash, uint32_t offset, uint32_t len);
+		int (*unlock) (struct spi_flash * flash, uint32_t offset, uint32_t len);
+		int (*set_4io) (struct spi_flash * flash, uint32_t op);
+		int (*set_qpi) (struct spi_flash * flash, uint32_t op);
 
-		int (*set_encrypt) (u32_t op);
+		int (*set_encrypt) (uint32_t op);
 
 		void *priv;
 	};
 
 	struct spi_flash_spec_s {
-		u16_t id_manufacturer;
-		u16_t table_num;
+		uint16_t id_manufacturer;
+		uint16_t table_num;
 		struct spi_flash_params *table;
 	};
 
 	struct spi_flash_params {
-		u16_t idcode1;
-		u16_t idcode2;
-		u16_t page_size;
-		u16_t sector_size;
-		u16_t nr_sectors;
-		u16_t nr_blocks;
-		u16_t support_qpi;
-		u16_t read_freq_max;
-		u16_t dummy_clocks;
+		uint16_t idcode1;
+		uint16_t idcode2;
+		uint16_t page_size;
+		uint16_t sector_size;
+		uint16_t nr_sectors;
+		uint16_t nr_blocks;
+		uint16_t support_qpi;
+		uint16_t read_freq_max;
+		uint16_t dummy_clocks;
 		const char *name;
 	};
 
@@ -137,7 +137,7 @@ extern "C" {
 
 	void uwp_spi_xip_init(void);
 
-	__ramfunc void spiflash_select_xip(u32_t op);
+	__ramfunc void spiflash_select_xip(uint32_t op);
 
 	__ramfunc void spiflash_set_clk(void);
 
@@ -146,7 +146,7 @@ extern "C" {
 
 	void spi_flash_free(struct spi_flash *flash);
 
-	void uwp_spi_dump(u32_t arg_in);
+	void uwp_spi_dump(uint32_t arg_in);
 
 static ALWAYS_INLINE unsigned int irq_lock_primask(void)
 {

--- a/uwp5/drivers/include/hal_sfc_hal.h
+++ b/uwp5/drivers/include/hal_sfc_hal.h
@@ -270,46 +270,46 @@ typedef enum lock_pattern {
 } LOCK_PATTERN_E;
 
 struct spi_flash_lock_desc {
-	u8_t reg2_value;
-	u8_t reg1_value;
+	uint8_t reg2_value;
+	uint8_t reg1_value;
 
-	u8_t lock_pattern;
+	uint8_t lock_pattern;
 };
 
 struct spi_flash_lock_pattern {
-	u8_t lock_pattern;
+	uint8_t lock_pattern;
 
-	u32_t start_addr;
-	u32_t size;
+	uint32_t start_addr;
+	uint32_t size;
 };
 
-void spiflash_cmd_read(struct spi_flash *flash, const u8_t * cmd,
-		       u32_t cmd_len, u32_t address, const void *data_in,
-		       u32_t data_len);
-void spiflash_cmd_write(struct spi_flash *flash, const u8_t * cmd,
-			u32_t cmd_len, const void *data_out, u32_t data_len);
+void spiflash_cmd_read(struct spi_flash *flash, const uint8_t * cmd,
+		       uint32_t cmd_len, uint32_t address, const void *data_in,
+		       uint32_t data_len);
+void spiflash_cmd_write(struct spi_flash *flash, const uint8_t * cmd,
+			uint32_t cmd_len, const void *data_out, uint32_t data_len);
 #define SR_QE		(1 << 9)
 #define SR_LOCK		(0)
 #define SR_UNLOCK	(0)
 
-LOCK_PATTERN_E spiflash_get_lock_pattern(u32_t start_addr, u32_t size,
+LOCK_PATTERN_E spiflash_get_lock_pattern(uint32_t start_addr, uint32_t size,
 					 const struct spi_flash_lock_desc
-					 *lock_table, u32_t lock_table_size);
-BYTE_NUM_E spi_flash_addr(u32_t * addr, u32_t support_4addr);
+					 *lock_table, uint32_t lock_table_size);
+BYTE_NUM_E spi_flash_addr(uint32_t * addr, uint32_t support_4addr);
 __ramfunc int spiflash_cmd_poll_bit(struct spi_flash *flash,
-	unsigned long timeout, u8_t cmd, u32_t poll_bit, u32_t bit_value);
+	unsigned long timeout, uint8_t cmd, uint32_t poll_bit, uint32_t bit_value);
 int spiflash_cmd_wait_ready(struct spi_flash *flash, unsigned long timeout);
-int spiflash_cmd_erase(struct spi_flash *flash, u8_t erase_cmd, u32_t offset);
-int spiflash_cmd_program(struct spi_flash *flash, u32_t offset, u32_t len,
-			 const void *buf, u8_t cmd);
-int spiflash_cmd_spi_read(struct spi_flash *flash, u8_t cmd_read,
-			  u8_t dummy_bytes);
-int spiflash_cmd_qpi_read(struct spi_flash *flash, u8_t cmd_read,
-			  u8_t dummy_bytes);
+int spiflash_cmd_erase(struct spi_flash *flash, uint8_t erase_cmd, uint32_t offset);
+int spiflash_cmd_program(struct spi_flash *flash, uint32_t offset, uint32_t len,
+			 const void *buf, uint8_t cmd);
+int spiflash_cmd_spi_read(struct spi_flash *flash, uint8_t cmd_read,
+			  uint8_t dummy_bytes);
+int spiflash_cmd_qpi_read(struct spi_flash *flash, uint8_t cmd_read,
+			  uint8_t dummy_bytes);
 
 int spiflash_write_enable(struct spi_flash *flash);
 int spiflash_write_disable(struct spi_flash *flash);
-int spiflash_write(struct spi_flash *flash, u32_t offset, u32_t len,
+int spiflash_write(struct spi_flash *flash, uint32_t offset, uint32_t len,
 		   const void *buf);
 int spiflash_erase_chip(struct spi_flash *flash);
 int spiflash_suspend(struct spi_flash *flash);
@@ -320,21 +320,21 @@ __ramfunc int spiflash_reset_anyway(void);
 int spiflash_init(void);
 struct spi_flash *flash_ctr(void);
 
-//void spi_read(SFC_CMD_DES_T * cmd_des_ptr, u32_t cmd_len, u32_t * din);
-//void spi_write(SFC_CMD_DES_T * cmd_des_ptr, u32_t cmd_len);
+//void spi_read(SFC_CMD_DES_T * cmd_des_ptr, uint32_t cmd_len, uint32_t * din);
+//void spi_write(SFC_CMD_DES_T * cmd_des_ptr, uint32_t cmd_len);
 void spi_write_cmd(struct spi_flash *flash, const void *cmd,
 		   unsigned int cmd_len);
-void spi_data_read(struct spi_flash *flash, const u8_t * cmd,
-		   u32_t cmd_len, u32_t address, const void *data_in,
-		   u32_t data_len);
+void spi_data_read(struct spi_flash *flash, const uint8_t * cmd,
+		   uint32_t cmd_len, uint32_t address, const void *data_in,
+		   uint32_t data_len);
 void spi_write_data(struct spi_flash *flash, const void *data_out,
-		    u32_t data_len);
-void spi_read_data(struct spi_flash *flash, void *data_in, u32_t data_len);
-__ramfunc void create_cmd(SFC_CMD_DES_T *cmd_desc_ptr, u32_t cmd,
-		u32_t byte_len, CMD_MODE_E cmd_mode,
+		    uint32_t data_len);
+void spi_read_data(struct spi_flash *flash, void *data_in, uint32_t data_len);
+__ramfunc void create_cmd(SFC_CMD_DES_T *cmd_desc_ptr, uint32_t cmd,
+		uint32_t byte_len, CMD_MODE_E cmd_mode,
 		BIT_MODE_E bit_mode, SEND_MODE_E send_mode);
 __ramfunc void spiflash_set_xip_cmd(struct spi_flash *flash,
-		const u8_t *cmd_read, u8_t dummy_bytes);
+		const uint8_t *cmd_read, uint8_t dummy_bytes);
 
 
 #ifdef __cplusplus

--- a/uwp5/drivers/include/hal_sfc_phy.h
+++ b/uwp5/drivers/include/hal_sfc_phy.h
@@ -378,7 +378,7 @@ extern "C" {
 		volatile SFC_TYPE_BUF2_U type_buf2;
 	} SFC_REG_T;
 
-#define SFC_REG_NUM         (sizeof(SFC_REG_T)/sizeof(u32_t))
+#define SFC_REG_NUM         (sizeof(SFC_REG_T)/sizeof(uint32_t))
 
 #define SFC_CLK_OUT_DIV_1			(0x0)
 #define SFC_CLK_OUT_DIV_2			BIT(0)
@@ -453,44 +453,44 @@ extern "C" {
 #define SPI_CMD_DATA_END        0x02
 
 	typedef struct _sfc_cmd_des {
-		u32_t cmd;
-		u32_t cmd_byte_len;
-		u32_t is_valid;
+		uint32_t cmd;
+		uint32_t cmd_byte_len;
+		uint32_t is_valid;
 		CMD_MODE_E cmd_mode;
 		BIT_MODE_E bit_mode;
 		SEND_MODE_E send_mode;
 	} SFC_CMD_DES_T, *SFC_CMD_DES_PTR;
 
-	void sfcdrv_setcmdencryptcfgreg(u32_t cmdmode);
+	void sfcdrv_setcmdencryptcfgreg(uint32_t cmdmode);
 	void sfcdrv_setcmdcfgreg(CMD_MODE_E cmdmode, BIT_MODE_E bitmode,
 			INI_ADD_SEL_E iniAddSel);
 	void sfcdrv_softreq(void);
 	void sfcdrv_cmd_bufclr(void);
 	void sfcdrv_typebufclr(void);
 	void sfcdrv_intclr(void);
-	u32_t sfcdrv_getstatus(void);
-	void sfcdrv_cstimingcfg(u32_t value);
-	void sfcdrv_rdtimingcfg(u32_t value);
-	void sfcdrv_clkcfg(u32_t value);
-	void sfcdrv_cscfg(u32_t value);
-	void sfcdrv_endiancfg(u32_t value);
-	void sfcdrv_setcmdbuf(CMD_BUF_INDEX_E index, u32_t value);
+	uint32_t sfcdrv_getstatus(void);
+	void sfcdrv_cstimingcfg(uint32_t value);
+	void sfcdrv_rdtimingcfg(uint32_t value);
+	void sfcdrv_clkcfg(uint32_t value);
+	void sfcdrv_cscfg(uint32_t value);
+	void sfcdrv_endiancfg(uint32_t value);
+	void sfcdrv_setcmdbuf(CMD_BUF_INDEX_E index, uint32_t value);
 	void sfcdrv_setcmdbufex(CMD_BUF_INDEX_E index,
-		const u8_t *buf, u32_t count);
-	u32_t sfcdrv_getcmdbuf(CMD_BUF_INDEX_E index);
+		const uint8_t *buf, uint32_t count);
+	uint32_t sfcdrv_getcmdbuf(CMD_BUF_INDEX_E index);
 	__ramfunc void sfcdrv_settypeinfbuf(CMD_BUF_INDEX_E index,
 			BIT_MODE_E bitmode,
 			BYTE_NUM_E bytenum, CMD_MODE_E cmdmode,
 			SEND_MODE_E sendmode);
 	__ramfunc void sfcdrv_resetallbuf(void);
 	__ramfunc void sfcdrv_setreadbuf(SFC_CMD_DES_T *cmd_des_ptr,
-			u32_t cmd_flag);
+			uint32_t cmd_flag);
 	__ramfunc void sfcdrv_setcmddata(SFC_CMD_DES_T *cmd_des_ptr,
-			u32_t cmd_flag);
-	__ramfunc void sfcdrv_getreadbuf(u32_t *buffer, u32_t word_cnt);
-	void sfcdrv_getbuf(void *buffer, u32_t nbytes);
-	__ramfunc void sfcdrv_intcfg(u32_t op);
-	__ramfunc void sfcdrv_clkcfg(u32_t value);
+			uint32_t cmd_flag);
+	__ramfunc void sfcdrv_getreadbuf(uint32_t *buffer, uint32_t word_cnt);
+	void sfcdrv_getbuf(void *buffer, uint32_t nbytes);
+	__ramfunc void sfcdrv_intcfg(uint32_t op);
+	__ramfunc void sfcdrv_clkcfg(uint32_t value);
 	__ramfunc void sfcdrv_req(void);
 
 #ifdef __cplusplus

--- a/uwp5/drivers/include/hal_sys.h
+++ b/uwp5/drivers/include/hal_sys.h
@@ -94,24 +94,24 @@ extern "C" {
 	};
 
 	struct uwp_sys {
-		u32_t rst;
-		u32_t mcu_soft_rst;
-		u32_t rstn_index;
-		u32_t sys_soft_rst;
-		u32_t eb;
-		u32_t eb1;
+		uint32_t rst;
+		uint32_t mcu_soft_rst;
+		uint32_t rstn_index;
+		uint32_t sys_soft_rst;
+		uint32_t eb;
+		uint32_t eb1;
 	};
 
-	static inline void uwp_sys_enable(u32_t bits) {
+	static inline void uwp_sys_enable(uint32_t bits) {
 		sci_glb_set(REG_APB_EB, bits);
 	}
 
-	static inline void uwp_sys_disable(u32_t bits) {
+	static inline void uwp_sys_disable(uint32_t bits) {
 		sci_glb_clr(REG_APB_EB, bits);
 	}
 
-	static inline void uwp_sys_reset(u32_t bits) {
-		u32_t wait = 50;
+	static inline void uwp_sys_reset(uint32_t bits) {
+		uint32_t wait = 50;
 
 		sci_glb_set(REG_APB_RST, bits);
 		while(wait--){}

--- a/uwp5/drivers/include/hal_uart.h
+++ b/uwp5/drivers/include/hal_uart.h
@@ -35,134 +35,134 @@ extern "C" {
 	};
 
 	typedef struct uart_txd {
-		u32_t txd	:8;
-		u32_t rsvd	:24;
+		uint32_t txd	:8;
+		uint32_t rsvd	:24;
 	}txd_t;
 
 	typedef struct uart_rxd {
-		u32_t rxd	:8;
-		u32_t rsvd	:24;
+		uint32_t rxd	:8;
+		uint32_t rsvd	:24;
 	}rxd_t;
 
 	typedef struct uart_sts1 {
-		u32_t rxf_cnt		:7;
-		u32_t rsvd0			:1;
-		u32_t txf_cnt		:7;
-		u32_t rsvd1			:17;
+		uint32_t rxf_cnt		:7;
+		uint32_t rsvd0			:1;
+		uint32_t txf_cnt		:7;
+		uint32_t rsvd1			:17;
 	}sts1_t;
 
 	typedef union uart_ctrl0 {
-		u32_t reg;
+		uint32_t reg;
 
 		struct {
-			u32_t odd_parity	:1;
-			u32_t parity_en		:1;
-			u32_t byte_len		:2;
-			u32_t stop_bit_num	:2;
-			u32_t rts_reg		:1;
-			u32_t send_brk_en	:1;
-			u32_t dtr_reg		:1;
-			u32_t ir_tx_iv		:1;
-			u32_t ir_rx_iv		:1;
-			u32_t ir_tx_en		:1;
-			u32_t ir_dplx		:1;
-			u32_t ir_wctl		:1;
-			u32_t rsvd0			:1;
-			u32_t mode_sel		:1;
-			u32_t rsvd1			:16;
+			uint32_t odd_parity	:1;
+			uint32_t parity_en		:1;
+			uint32_t byte_len		:2;
+			uint32_t stop_bit_num	:2;
+			uint32_t rts_reg		:1;
+			uint32_t send_brk_en	:1;
+			uint32_t dtr_reg		:1;
+			uint32_t ir_tx_iv		:1;
+			uint32_t ir_rx_iv		:1;
+			uint32_t ir_tx_en		:1;
+			uint32_t ir_dplx		:1;
+			uint32_t ir_wctl		:1;
+			uint32_t rsvd0			:1;
+			uint32_t mode_sel		:1;
+			uint32_t rsvd1			:16;
 		}bit;
 	}ctrl0_t;
 
 	typedef union uart_ctrl1 {
-		u32_t reg;
+		uint32_t reg;
 
 		struct {
-			u32_t rcv_hw_flow_thld	:7;
-			u32_t rcv_hw_flow_en	:1;
-			u32_t tx_hw_flow_en		:1;
-			u32_t rx_tout_thld		:5;
-			u32_t loop_back			:1;
-			u32_t dma_en			:1;
-			u32_t rsvd				:16;
+			uint32_t rcv_hw_flow_thld	:7;
+			uint32_t rcv_hw_flow_en	:1;
+			uint32_t tx_hw_flow_en		:1;
+			uint32_t rx_tout_thld		:5;
+			uint32_t loop_back			:1;
+			uint32_t dma_en			:1;
+			uint32_t rsvd				:16;
 		}bit;
 	}ctrl1_t;
 
 	typedef union uart_ctrl2 {
-		u32_t reg;
+		uint32_t reg;
 		struct {
-			u32_t rxf_full_thld		:7;
-			u32_t rsvd0				:1;
-			u32_t txf_empty_thld	:7;
-			u32_t rsvd1				:17;
+			uint32_t rxf_full_thld		:7;
+			uint32_t rsvd0				:1;
+			uint32_t txf_empty_thld	:7;
+			uint32_t rsvd1				:17;
 		}bit;
 	}ctrl2_t;
 
 	typedef struct uart_cdk0 {
-		u32_t cdk0		:16;
-		u32_t rsvd		:16;
+		uint32_t cdk0		:16;
+		uint32_t rsvd		:16;
 	}cdk0_t;
 
 	typedef struct uart_dspwait {
-		u32_t dspwait			:4;
-		u32_t rx_dma_mod_sel	:1;
-		u32_t tx_dma_mod_sel	:1;
+		uint32_t dspwait			:4;
+		uint32_t rx_dma_mod_sel	:1;
+		uint32_t tx_dma_mod_sel	:1;
 	}dspwait_t;
 
 	struct uwp_uart {
 		txd_t		txd;
 		rxd_t		rxd;
-		u32_t		sts0;
+		uint32_t		sts0;
 		sts1_t		sts1;
-		u32_t		ien;
-		u32_t		iclr;
+		uint32_t		ien;
+		uint32_t		iclr;
 		ctrl0_t		ctrl0;
 		ctrl1_t		ctrl1;
 		ctrl2_t		ctrl2;
 		cdk0_t		cdk0;
-		u32_t		sts2;
+		uint32_t		sts2;
 		dspwait_t	dspwait;
 	};
 
-static inline u32_t uwp_uart_rx_ready(volatile struct uwp_uart *uart)
+static inline uint32_t uwp_uart_rx_ready(volatile struct uwp_uart *uart)
 {
 	return (uart->sts0 >> UART_RXF_FULL) & 0x1;
 }
 
-static inline u32_t uwp_uart_tx_ready(volatile struct uwp_uart *uart)
+static inline uint32_t uwp_uart_tx_ready(volatile struct uwp_uart *uart)
 {
 	return (uart->sts0 >> UART_TXF_EMPTY) & 0x1;
 }
 
-static inline u8_t uwp_uart_read(volatile struct uwp_uart *uart)
+static inline uint8_t uwp_uart_read(volatile struct uwp_uart *uart)
 {
 	return uart->rxd.rxd;
 }
 
 static inline void uwp_uart_write(volatile struct uwp_uart *uart,
-		u8_t c)
+		uint8_t c)
 {
 	uart->txd.txd = c;
 }
 
-static inline u32_t uwp_uart_trans_over(volatile struct uwp_uart *uart)
+static inline uint32_t uwp_uart_trans_over(volatile struct uwp_uart *uart)
 {
 	return uart->sts0 & BIT(UART_TRANS_OVER);
 }
 
 static inline void uwp_uart_set_cdk(volatile struct uwp_uart *uart,
-		u32_t cdk)
+		uint32_t cdk)
 {
 	uart->cdk0.cdk0 = cdk;
 }
 
 static inline void uwp_uart_set_stop_bit_num(volatile struct uwp_uart *uart,
-		u32_t stop_bit_num)
+		uint32_t stop_bit_num)
 {
 	uart->ctrl0.bit.stop_bit_num = stop_bit_num;
 }
 
 static inline void uwp_uart_set_byte_len(volatile struct uwp_uart *uart,
-		u32_t byte_len)
+		uint32_t byte_len)
 {
 	uart->ctrl0.bit.byte_len = byte_len;
 }
@@ -180,24 +180,24 @@ static inline void uwp_uart_init(volatile struct uwp_uart *uart)
 }
 
 static inline void uwp_uart_int_enable(volatile struct uwp_uart *uart,
-		u32_t flags)
+		uint32_t flags)
 {
 	uart->ien |= flags;
 }
 
 static inline void uwp_uart_int_disable(volatile struct uwp_uart *uart,
-		u32_t flags)
+		uint32_t flags)
 {
 	uart->ien &= ~flags;
 }
 
 static inline void uwp_uart_int_clear(volatile struct uwp_uart *uart,
-		u32_t flags)
+		uint32_t flags)
 {
 	uart->iclr |= flags;
 }
 
-static inline u32_t uwp_uart_status(volatile struct uwp_uart *uart)
+static inline uint32_t uwp_uart_status(volatile struct uwp_uart *uart)
 {
 	return uart->sts0;
 }

--- a/uwp5/drivers/include/hal_wdg.h
+++ b/uwp5/drivers/include/hal_wdg.h
@@ -51,19 +51,19 @@ extern "C" {
 #define WDG_IRQ_MSK_BIT BIT(0)
 
 	struct uwp_wdg {
-		u32_t load_low;
-		u32_t load_high;
-		u32_t ctrl;
-		u32_t int_clr;
-		u32_t int_raw;
-		u32_t int_mask;
-		u32_t cnt_low;
-		u32_t cnt_high;
-		u32_t lock;
-		u32_t cnt_rd_low;
-		u32_t cnt_rd_high;
-		u32_t irq_val_low;
-		u32_t irq_val_high;
+		uint32_t load_low;
+		uint32_t load_high;
+		uint32_t ctrl;
+		uint32_t int_clr;
+		uint32_t int_raw;
+		uint32_t int_mask;
+		uint32_t cnt_low;
+		uint32_t cnt_high;
+		uint32_t lock;
+		uint32_t cnt_rd_low;
+		uint32_t cnt_rd_high;
+		uint32_t irq_val_low;
+		uint32_t irq_val_high;
 	};
 
 	static inline void uwp_wdg_lock(void)
@@ -76,9 +76,9 @@ extern "C" {
 		sci_write32(REG_WDG_LOCK, WDG_UNLOCK_KEY);
 	}
 
-	static inline void uwp_wdg_set_mode(u32_t mode)
+	static inline void uwp_wdg_set_mode(uint32_t mode)
 	{
-		u32_t mode_bitmap;
+		uint32_t mode_bitmap;
 
 		switch (mode){
 			case WDG_MODE_RESET:
@@ -106,10 +106,10 @@ extern "C" {
 		uwp_wdg_lock();
 	}
 
-	static inline void uwp_wdg_load(u32_t value)
+	static inline void uwp_wdg_load(uint32_t value)
 	{
 #ifndef WDG_NEWMODE
-		u32_t cnt = 0;
+		uint32_t cnt = 0;
 #endif
 		value = value * 32768 / 1000;
 		uwp_wdg_unlock();
@@ -123,10 +123,10 @@ extern "C" {
 		uwp_wdg_lock();
 	}
 
-	static inline void uwp_wdg_load_irq(u32_t value)
+	static inline void uwp_wdg_load_irq(uint32_t value)
 	{
 #ifndef WDG_NEWMODE
-		u32_t cnt = 0;
+		uint32_t cnt = 0;
 #endif
 		uwp_wdg_unlock();
 		value = value * 32768 / 1000;
@@ -167,9 +167,9 @@ extern "C" {
 		uwp_wdg_lock();
 	}
 
-	static inline u32_t uwp_wdg_get_counter(void)
+	static inline uint32_t uwp_wdg_get_counter(void)
 	{
-		u32_t value = 0;
+		uint32_t value = 0;
 
 		uwp_wdg_unlock();
 

--- a/uwp5/drivers/src/bt/sipc.c
+++ b/uwp5/drivers/src/bt/sipc.c
@@ -128,18 +128,18 @@ void sipc_test()
 {
 }
 
-static void bt_spi_handle_vendor_evt(u8_t *rxmsg)
+static void bt_spi_handle_vendor_evt(uint8_t *rxmsg)
 {
 
 }
 
 
-static u8_t adv_cache[50] = {0};
+static uint8_t adv_cache[50] = {0};
 #define ADV_RECV_TIMEOUT K_SECONDS(1)
 static struct net_buf *alloc_adv_buf(unsigned char *src)
 {
 	struct net_buf *buf = NULL;
-	u8_t length = src[EVT_ADV_LENGTH];
+	uint8_t length = src[EVT_ADV_LENGTH];
 
 	if (!memcmp(adv_cache, src + EVT_ADV_LENGTH, length + 1)) {
 		//BTD("dropped surplus adv");
@@ -187,7 +187,7 @@ static void tx_thread(void)
 static void rx_thread(void)
 {
 	int ret;
-	u32_t left_length;
+	uint32_t left_length;
 	struct net_buf *buf;
 	unsigned char *rxmsg = NULL;
 	struct bt_hci_acl_hdr acl_hdr;

--- a/uwp5/drivers/src/bt/uki_utlis.c
+++ b/uwp5/drivers/src/bt/uki_utlis.c
@@ -70,11 +70,11 @@ void uki_hex_dump_block(char *tag, unsigned char *bin, size_t binsz)
 		uki_hexdump(tag, bin + i * HEX_DUMP_BLOCK_SIZE, tail);
 }
 
-void uki_str2hex(u8_t *dst, u8_t *src, size_t size)
+void uki_str2hex(uint8_t *dst, uint8_t *src, size_t size)
 {
     int len;
     int i, j;
-    u8_t c;
+    uint8_t c;
 
     len = strlen(src);
     if (len > size * 2) {

--- a/uwp5/drivers/src/bt/uki_utlis.h
+++ b/uwp5/drivers/src/bt/uki_utlis.h
@@ -70,7 +70,7 @@ static inline void set_stack_log_level(int level) {
 
 void uki_hex_dump_block(char *tag, unsigned char *bin, size_t binsz);
 void uki_hex(char *dst, unsigned char *src, size_t binsz);
-void uki_str2hex(u8_t *dst, u8_t *src, size_t size);
+void uki_str2hex(uint8_t *dst, uint8_t *src, size_t size);
 void uki_hexdump(char *tag, unsigned char *bin, size_t binsz);
 void uki_hex_dump_block_ex(unsigned char type, char *tag, unsigned char *bin, size_t binsz);
 

--- a/uwp5/drivers/src/bt/uwp5661.c
+++ b/uwp5/drivers/src/bt/uwp5661.c
@@ -237,7 +237,7 @@ int get_pskey_buf(void *buf)
 void set_mac_address(uint8_t *addr)
 {
     uint8_t default_addr[6] = {0x00, 0x00, 0x00, 0xDA, 0x45, 0x40};
-    u32_t random;
+    uint32_t random;
 
     if(0 == memcmp(bt_info.address, default_addr,sizeof(default_addr))) {
         random =sys_rand32_get();

--- a/uwp5/drivers/src/sfc/hal_sfc.c
+++ b/uwp5/drivers/src/sfc/hal_sfc.c
@@ -19,7 +19,7 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 
-void uwp_spi_dump(u32_t arg_in)
+void uwp_spi_dump(uint32_t arg_in)
 {
 	LOG_ERR("dump SFC register:[#### %d ####]\n", arg_in);
 
@@ -46,8 +46,8 @@ void uwp_spi_dump(u32_t arg_in)
 		sci_read32(REG_AON_CLK_RF_CGM_SFC_2X_CFG));
 }
 
-__ramfunc void create_cmd(SFC_CMD_DES_T *cmd_desc_ptr, u32_t cmd,
-		u32_t byte_len,
+__ramfunc void create_cmd(SFC_CMD_DES_T *cmd_desc_ptr, uint32_t cmd,
+		uint32_t byte_len,
 		CMD_MODE_E cmd_mode, BIT_MODE_E bit_mode, SEND_MODE_E send_mode)
 {
 	cmd_desc_ptr->cmd = cmd;
@@ -57,12 +57,12 @@ __ramfunc void create_cmd(SFC_CMD_DES_T *cmd_desc_ptr, u32_t cmd,
 	cmd_desc_ptr->send_mode = send_mode;
 }
 
-__ramfunc void spiflash_read_write(SFC_CMD_DES_T *cmd_des_ptr, u32_t cmd_len,
-		u32_t * din)
+__ramfunc void spiflash_read_write(SFC_CMD_DES_T *cmd_des_ptr, uint32_t cmd_len,
+		uint32_t * din)
 {
-	u32_t i;
-	u32_t *read_ptr = din;
-	u32_t read_count = 0;
+	uint32_t i;
+	uint32_t *read_ptr = din;
+	uint32_t read_count = 0;
 
 	SCI_ASSERT(cmd_len <= 12);
 
@@ -86,9 +86,9 @@ __ramfunc void spiflash_read_write(SFC_CMD_DES_T *cmd_des_ptr, u32_t cmd_len,
 		sfcdrv_getreadbuf(read_ptr, read_count);
 }
 
-void spiflash_read_write_sec(SFC_CMD_DES_T * cmd_des_ptr, u32_t cmd_len)
+void spiflash_read_write_sec(SFC_CMD_DES_T * cmd_des_ptr, uint32_t cmd_len)
 {
-	u32_t i;
+	uint32_t i;
 
 	SCI_ASSERT(cmd_len <= 12);
 
@@ -112,9 +112,9 @@ void spiflash_read_write_sec(SFC_CMD_DES_T * cmd_des_ptr, u32_t cmd_len)
 }
 
 __ramfunc static void spiflash_get_status(struct spi_flash *flash,
-		u8_t *status1, u8_t *status2)
+		uint8_t *status1, uint8_t *status2)
 {
-	u8_t cmd = 0;
+	uint8_t cmd = 0;
 	char logbuf[256] = { 0 };
 
 	cmd = CMD_READ_STATUS1;
@@ -131,10 +131,10 @@ __ramfunc static void spiflash_get_status(struct spi_flash *flash,
 	LOG_DBG("[%s]", logbuf);
 }
 
-__ramfunc BYTE_NUM_E spi_flash_addr(u32_t *addr, u32_t support_4addr)
+__ramfunc BYTE_NUM_E spi_flash_addr(uint32_t *addr, uint32_t support_4addr)
 {
-	u8_t cmd[4] = { 0 };
-	u32_t address = *addr;
+	uint8_t cmd[4] = { 0 };
+	uint32_t address = *addr;
 
 	cmd[0] = ((address >> 0) & (0xFF));
 	cmd[1] = ((address >> 8) & (0xFF));
@@ -163,9 +163,9 @@ __ramfunc BYTE_NUM_E spi_flash_addr(u32_t *addr, u32_t support_4addr)
 
 __ramfunc struct spi_flash_params *spiflash_scan(void)
 {
-	u8_t i;
-	u8_t idcode[5];
-	u16_t jedec, ext_jedec, manufacturer_id;
+	uint8_t i;
+	uint8_t idcode[5];
+	uint16_t jedec, ext_jedec, manufacturer_id;
 	struct spi_flash_spec_s *spi_spec;
 	SFC_CMD_DES_T cmd_desc[2];
 	struct spi_flash_params *params = NULL;
@@ -176,14 +176,14 @@ __ramfunc struct spi_flash_params *spiflash_scan(void)
 	CREATE_CMD_(cmd_desc[1], 0, BYTE_NUM_3,
 		CMD_MODE_READ, BIT_MODE_1);
 
-	spiflash_read_write(cmd_desc, 2, (u32_t *) idcode);
+	spiflash_read_write(cmd_desc, 2, (uint32_t *) idcode);
 
 	spiflash_select_xip(TRUE);
 
 	LOG_INF("SF: new Got idcode 0: 0x%x 1:0x%x 2:0x%x 3:0x%x 4:0x%x\n",
 			idcode[0], idcode[1], idcode[2], idcode[3], idcode[4]);
 
-	manufacturer_id = (u16_t) idcode[0];
+	manufacturer_id = (uint16_t) idcode[0];
 	jedec = idcode[1] << 8 | idcode[2];
 	ext_jedec = idcode[3] << 8 | idcode[4];
 
@@ -218,14 +218,14 @@ __ramfunc struct spi_flash_params *spiflash_scan(void)
 	}
 }
 
-LOCK_PATTERN_E spiflash_get_lock_pattern(u32_t start_addr, u32_t size,
+LOCK_PATTERN_E spiflash_get_lock_pattern(uint32_t start_addr, uint32_t size,
 		const struct spi_flash_lock_desc *
-		lock_table, u32_t lock_table_size)
+		lock_table, uint32_t lock_table_size)
 {
 	LOCK_PATTERN_E lock_pattern = LOCK_PATTERN_MAX;
-	u32_t i = 0, j = 0;
-	u32_t lock_match_index = 0xFFFF;
-	u32_t delta_size = 0xFFFFFFFF;
+	uint32_t i = 0, j = 0;
+	uint32_t lock_match_index = 0xFFFF;
+	uint32_t delta_size = 0xFFFFFFFF;
 
 	for (i = 0; i < lock_table_size; i++) {
 		lock_pattern = (LOCK_PATTERN_E) (lock_table[i].lock_pattern);
@@ -251,10 +251,10 @@ LOCK_PATTERN_E spiflash_get_lock_pattern(u32_t start_addr, u32_t size,
 			[lock_match_index].lock_pattern);
 }
 
-__ramfunc void spiflash_set_xip(SFC_CMD_DES_T *cmd_des_ptr, u32_t cmd_len,
+__ramfunc void spiflash_set_xip(SFC_CMD_DES_T *cmd_des_ptr, uint32_t cmd_len,
 		BIT_MODE_E bit_mode)
 {
-	u32_t i;
+	uint32_t i;
 
 	sfcdrv_resetallbuf();
 	sfcdrv_setcmdcfgreg(CMD_MODE_READ, bit_mode, INI_CMD_BUF_7);
@@ -273,11 +273,11 @@ __ramfunc void spiflash_set_xip(SFC_CMD_DES_T *cmd_des_ptr, u32_t cmd_len,
 }
 
 __ramfunc void spiflash_set_xip_cmd(struct spi_flash *flash,
-		const u8_t *cmd_read, u8_t dummy_bytes)
+		const uint8_t *cmd_read, uint8_t dummy_bytes)
 {
 	SFC_CMD_DES_T cmd_desc[5];
-	u32_t cmd_desc_size = 0;
-	u32_t dummy[2] = { 0 };
+	uint32_t cmd_desc_size = 0;
+	uint32_t dummy[2] = { 0 };
 
 	BIT_MODE_E bitmode_cmd = BIT_MODE_1;
 	BIT_MODE_E bitmode_addr = BIT_MODE_1;
@@ -291,7 +291,7 @@ __ramfunc void spiflash_set_xip_cmd(struct spi_flash *flash,
 		bitmode_addr = BIT_MODE_4;
 		bitmode_dummy = BIT_MODE_4;
 		bitmode_data = BIT_MODE_4;
-		CREATE_CMD_(cmd_desc[0], (*(u32_t *) (cmd_read)) & 0xFF,
+		CREATE_CMD_(cmd_desc[0], (*(uint32_t *) (cmd_read)) & 0xFF,
 				BYTE_NUM_1, CMD_MODE_WRITE,
 			    bitmode_cmd);
 	} else {
@@ -331,13 +331,13 @@ __ramfunc void spiflash_set_xip_cmd(struct spi_flash *flash,
 		} else {
 			bitmode_data = BIT_MODE_1;
 		}
-		CREATE_CMD_(cmd_desc[0], (*(u32_t *) (cmd_read)) & 0xFF,
+		CREATE_CMD_(cmd_desc[0], (*(uint32_t *) (cmd_read)) & 0xFF,
 				BYTE_NUM_1, CMD_MODE_WRITE,
 				bitmode_cmd);
 	}
 
 	BYTE_NUM_E addr_byte_num = BYTE_NUM_3;
-	u32_t dest_addr;
+	uint32_t dest_addr;
 
 	dest_addr = cmd_read[1] << 16 | cmd_read[2] << 8 | cmd_read[3];
 	addr_byte_num =
@@ -396,15 +396,15 @@ __ramfunc void spiflash_set_xip_cmd(struct spi_flash *flash,
 	spiflash_set_xip(cmd_desc, cmd_desc_size, bitmode_data);
 }
 
-__ramfunc void spiflash_cmd_read(struct spi_flash *flash, const u8_t *cmd,
-		u32_t cmd_len, u32_t address, const void *data_in,
-		u32_t data_len)
+__ramfunc void spiflash_cmd_read(struct spi_flash *flash, const uint8_t *cmd,
+		uint32_t cmd_len, uint32_t address, const void *data_in,
+		uint32_t data_len)
 {
 	SFC_CMD_DES_T cmd_desc[4];
 	BIT_MODE_E bitmode = BIT_MODE_1;
 	BYTE_NUM_E data_byte_num = 0;
-	u32_t *data_ptr32 = (u32_t *) (data_in);
-	u32_t cmd_idx = 0;
+	uint32_t *data_ptr32 = (uint32_t *) (data_in);
+	uint32_t cmd_idx = 0;
 
 	SCI_ASSERT(cmd_len <= 4);
 	SCI_ASSERT(data_len <= 8);
@@ -456,17 +456,17 @@ __ramfunc void spiflash_cmd_read(struct spi_flash *flash, const u8_t *cmd,
 	spiflash_read_write(cmd_desc, cmd_idx, data_ptr32);
 }
 
-__ramfunc void spiflash_cmd_write(struct spi_flash *flash, const u8_t *cmd,
-		u32_t cmd_len, const void *data_out, u32_t data_len)
+__ramfunc void spiflash_cmd_write(struct spi_flash *flash, const uint8_t *cmd,
+		uint32_t cmd_len, const void *data_out, uint32_t data_len)
 {
 	SFC_CMD_DES_T cmd_desc[4];
 	BIT_MODE_E bitmode = BIT_MODE_1;
 	BYTE_NUM_E cmd_byte_num = 0;
 	BYTE_NUM_E data_byte_num = 0;
-	u32_t cmd_data = 0;
-	u32_t i = 0;
-	u8_t *data_ptr8 = (u8_t *) (data_out);
-	u32_t cmd_length = 2;
+	uint32_t cmd_data = 0;
+	uint32_t i = 0;
+	uint8_t *data_ptr8 = (uint8_t *) (data_out);
+	uint32_t cmd_length = 2;
 
 	SCI_ASSERT(cmd_len <= 4);
 	SCI_ASSERT(data_len <= 4);
@@ -529,9 +529,9 @@ __ramfunc void spiflash_cmd_write(struct spi_flash *flash, const u8_t *cmd,
 }
 
 __ramfunc int spiflash_cmd_poll_bit(struct spi_flash *flash,
-	unsigned long timeout, u8_t cmd, u32_t poll_bit, u32_t bit_value)
+	unsigned long timeout, uint8_t cmd, uint32_t poll_bit, uint32_t bit_value)
 {
-	u32_t status = 0;
+	uint32_t status = 0;
 
 	do {
 
@@ -560,10 +560,10 @@ __ramfunc int spiflash_cmd_wait_ready(struct spi_flash *flash,
 }
 
 __ramfunc int spiflash_cmd_erase(struct spi_flash *flash,
-		u8_t erase_cmd, u32_t offset)
+		uint8_t erase_cmd, uint32_t offset)
 {
-	u32_t addr;
-	u32_t dummp;
+	uint32_t addr;
+	uint32_t dummp;
 	int ret = 0;
 	SFC_CMD_DES_T cmd_desc[2];
 	BIT_MODE_E bitmode = BIT_MODE_1;
@@ -606,17 +606,17 @@ __attribute__ ((optimize("-O0"))) spiflash_write_page_sec(struct spi_flash
 		*flash,
 		SFC_CMD_DES_T *
 		cmd_des_ptr,
-		u32_t cmd_len,
+		uint32_t cmd_len,
 		const void *data,
-		u32_t data_len)
+		uint32_t data_len)
 {
-	u32_t i, j, k;
-	u32_t piece_bytes_max = (10 - 2) * 4;
-	u32_t cmd_write = cmd_des_ptr[0].cmd;
-	u32_t addr = cmd_des_ptr[1].cmd;
-	u32_t dest_addr = addr;
-	u32_t *data_ptr32 = (u32_t *) (data);
-	u32_t data_tmp[10];
+	uint32_t i, j, k;
+	uint32_t piece_bytes_max = (10 - 2) * 4;
+	uint32_t cmd_write = cmd_des_ptr[0].cmd;
+	uint32_t addr = cmd_des_ptr[1].cmd;
+	uint32_t dest_addr = addr;
+	uint32_t *data_ptr32 = (uint32_t *) (data);
+	uint32_t data_tmp[10];
 
 	BIT_MODE_E bitmode_cmd = BIT_MODE_1;
 	BIT_MODE_E bitmode_addr = BIT_MODE_1;
@@ -657,8 +657,8 @@ __attribute__ ((optimize("-O0"))) spiflash_write_page_sec(struct spi_flash
 
 	for (i = 0; i < data_len;) {
 		BYTE_NUM_E addr_byte_num = BYTE_NUM_3;
-		u32_t buffer_cnt = 0;
-		u32_t piece_cnt = min(piece_bytes_max, data_len - i);
+		uint32_t buffer_cnt = 0;
+		uint32_t piece_cnt = min(piece_bytes_max, data_len - i);
 
 		spiflash_write_enable(flash);
 
@@ -706,15 +706,15 @@ __attribute__ ((optimize("-O0"))) spiflash_write_page_sec(struct spi_flash
 }
 
 __ramfunc static int spiflash_write_page(struct spi_flash *flash,
-		SFC_CMD_DES_T * cmd_des_ptr, u32_t cmd_len,
-		const void *data, u32_t data_len)
+		SFC_CMD_DES_T * cmd_des_ptr, uint32_t cmd_len,
+		const void *data, uint32_t data_len)
 {
-	u32_t i, j;
-	u32_t piece_bytes_max = (12 - 2) * 4;
-	u32_t cmd_write = cmd_des_ptr[0].cmd;
-	u32_t addr = cmd_des_ptr[1].cmd;
-	u32_t dest_addr = addr;
-	u32_t *data_ptr32 = (u32_t *) (data);
+	uint32_t i, j;
+	uint32_t piece_bytes_max = (12 - 2) * 4;
+	uint32_t cmd_write = cmd_des_ptr[0].cmd;
+	uint32_t addr = cmd_des_ptr[1].cmd;
+	uint32_t dest_addr = addr;
+	uint32_t *data_ptr32 = (uint32_t *) (data);
 
 	BIT_MODE_E bitmode_cmd = BIT_MODE_1;
 	BIT_MODE_E bitmode_addr = BIT_MODE_1;
@@ -755,8 +755,8 @@ __ramfunc static int spiflash_write_page(struct spi_flash *flash,
 
 	for (i = 0; i < data_len;) {
 		BYTE_NUM_E addr_byte_num = BYTE_NUM_3;
-		u32_t buffer_cnt = 0;
-		u32_t piece_cnt = min(piece_bytes_max, data_len - i);
+		uint32_t buffer_cnt = 0;
+		uint32_t piece_cnt = min(piece_bytes_max, data_len - i);
 
 		spiflash_write_enable(flash);
 		dest_addr = addr;
@@ -780,7 +780,7 @@ __ramfunc static int spiflash_write_page(struct spi_flash *flash,
 				j = j + 4;
 			} else if (((piece_cnt - j) < 4)
 					&& ((piece_cnt - j) % 4)) {
-				u32_t tail_bytes = piece_cnt - j, byte_number =
+				uint32_t tail_bytes = piece_cnt - j, byte_number =
 					BYTE_NUM_1;
 				switch (tail_bytes) {
 					case 1:
@@ -816,17 +816,17 @@ __ramfunc static int spiflash_write_page(struct spi_flash *flash,
 
 int __attribute__ ((optimize("-O0"))) spiflash_cmd_program_sec(struct spi_flash
 		*flash,
-		u32_t offset,
-		u32_t len,
+		uint32_t offset,
+		uint32_t len,
 		const void *buf,
-		u8_t cmd)
+		uint8_t cmd)
 {
 	unsigned long page_addr, page_size;
 	unsigned int byte_addr;
-	u32_t chunk_len, actual;
+	uint32_t chunk_len, actual;
 	SFC_CMD_DES_T cmd_desc[2];
 	BIT_MODE_E bitmode = BIT_MODE_1;
-	u32_t data_len, space_len;
+	uint32_t data_len, space_len;
 	int ret = 0;
 
 	page_size = flash->page_size;
@@ -856,7 +856,7 @@ int __attribute__ ((optimize("-O0"))) spiflash_cmd_program_sec(struct spi_flash
 		CREATE_CMD_(cmd_desc[0], cmd, BYTE_NUM_1, CMD_MODE_WRITE,
 				bitmode);
 		CREATE_CMD_(cmd_desc[1],
-				(u32_t) (page_addr * page_size + byte_addr),
+				(uint32_t) (page_addr * page_size + byte_addr),
 				BYTE_NUM_4, CMD_MODE_WRITE, bitmode);
 
 		ret =
@@ -873,15 +873,15 @@ int __attribute__ ((optimize("-O0"))) spiflash_cmd_program_sec(struct spi_flash
 	return ret;
 }
 
-__ramfunc int spiflash_cmd_program(struct spi_flash *flash, u32_t offset,
-		u32_t len, const void *buf, u8_t cmd)
+__ramfunc int spiflash_cmd_program(struct spi_flash *flash, uint32_t offset,
+		uint32_t len, const void *buf, uint8_t cmd)
 {
 	unsigned long page_addr, page_size;
 	unsigned int byte_addr;
-	u32_t chunk_len, actual;
+	uint32_t chunk_len, actual;
 	SFC_CMD_DES_T cmd_desc[2];
 	BIT_MODE_E bitmode = BIT_MODE_1;
-	u32_t data_len, space_len;
+	uint32_t data_len, space_len;
 	int ret = 0;
 
 	page_size = flash->page_size;
@@ -912,7 +912,7 @@ __ramfunc int spiflash_cmd_program(struct spi_flash *flash, u32_t offset,
 		CREATE_CMD_(cmd_desc[0], cmd, BYTE_NUM_1, CMD_MODE_WRITE,
 				bitmode);
 		CREATE_CMD_(cmd_desc[1],
-				(u32_t) (page_addr * page_size + byte_addr),
+				(uint32_t) (page_addr * page_size + byte_addr),
 				BYTE_NUM_4, CMD_MODE_WRITE, bitmode);
 
 		ret =
@@ -935,8 +935,8 @@ __ramfunc int spiflash_cmd_program(struct spi_flash *flash, u32_t offset,
 
 __ramfunc int spiflash_write_enable(struct spi_flash *flash)
 {
-	u32_t timeout = SPI_FLASH_WEL_TIMEOUT;
-	u8_t cmd = CMD_WRITE_ENABLE;
+	uint32_t timeout = SPI_FLASH_WEL_TIMEOUT;
+	uint8_t cmd = CMD_WRITE_ENABLE;
 
 	spiflash_cmd_write(flash, &cmd, 1, NULL, 0);
 
@@ -960,10 +960,10 @@ int spiflash_write_disable(struct spi_flash *flash)
 	return 0;
 }
 
-__ramfunc int spiflash_lock(struct spi_flash *flash, u32_t offset, u32_t len)
+__ramfunc int spiflash_lock(struct spi_flash *flash, uint32_t offset, uint32_t len)
 {
-	u8_t cmd;
-	u8_t status1 = 0, status2 = 0;
+	uint8_t cmd;
+	uint8_t status1 = 0, status2 = 0;
 	int dout = 0;
 	int ret = 0;
 
@@ -985,10 +985,10 @@ __ramfunc int spiflash_lock(struct spi_flash *flash, u32_t offset, u32_t len)
 	return ret;
 }
 
-__ramfunc int spiflash_unlock(struct spi_flash *flash, u32_t offset, u32_t len)
+__ramfunc int spiflash_unlock(struct spi_flash *flash, uint32_t offset, uint32_t len)
 {
-	u8_t cmd;
-	u8_t status1 = 0, status2 = 0;
+	uint8_t cmd;
+	uint8_t status1 = 0, status2 = 0;
 	int dout = 0;
 	int ret = 0;
 
@@ -1036,23 +1036,23 @@ __ramfunc int spiflash_reset_anyway(void)
 	return 0;
 }
 
-int spiflash_write_sec(struct spi_flash *flash, u32_t offset,
-		u32_t len, const void *buf)
+int spiflash_write_sec(struct spi_flash *flash, uint32_t offset,
+		uint32_t len, const void *buf)
 {
 	return spiflash_cmd_program_sec(flash, offset, len, buf,
 			CMD_PAGE_PROGRAM);
 }
 
-__ramfunc int spiflash_write(struct spi_flash *flash, u32_t offset,
-		u32_t len, const void *buf)
+__ramfunc int spiflash_write(struct spi_flash *flash, uint32_t offset,
+		uint32_t len, const void *buf)
 {
 	return spiflash_cmd_program(flash, offset, len, buf, CMD_PAGE_PROGRAM);
 }
 
-__ramfunc int spiflash_erase(struct spi_flash *flash, u32_t offset, u32_t len)
+__ramfunc int spiflash_erase(struct spi_flash *flash, uint32_t offset, uint32_t len)
 {
-	u32_t i, sectors_nr;
-	u32_t dummp;
+	uint32_t i, sectors_nr;
+	uint32_t dummp;
 
 	dummp = len % flash->sector_size;
 	if (dummp) {
@@ -1071,7 +1071,7 @@ __ramfunc int spiflash_erase(struct spi_flash *flash, u32_t offset, u32_t len)
 
 int spiflash_suspend(struct spi_flash *flash)
 {
-	u8_t cmd = CMD_PE_SUSPEND;
+	uint8_t cmd = CMD_PE_SUSPEND;
 
 	spiflash_cmd_write(flash, &cmd, 1, NULL, 0);
 	return 0;
@@ -1079,7 +1079,7 @@ int spiflash_suspend(struct spi_flash *flash)
 
 int spiflash_resume(struct spi_flash *flash)
 {
-	u8_t cmd = CMD_PE_RESUME;
+	uint8_t cmd = CMD_PE_RESUME;
 
 	spiflash_cmd_write(flash, &cmd, 1, NULL, 0);
 	return 0;
@@ -1089,7 +1089,7 @@ __ramfunc int spiflash_erase_chip(struct spi_flash *flash)
 {
 	int ret = 0;
 
-	u8_t cmd = CMD_CHIP_ERASE;
+	uint8_t cmd = CMD_CHIP_ERASE;
 
 	spiflash_write_enable(flash);
 	spiflash_cmd_write(flash, &cmd, 1, NULL, 0);
@@ -1101,17 +1101,17 @@ __ramfunc int spiflash_erase_chip(struct spi_flash *flash)
 	return ret;
 }
 
-u32_t spiflash_read_common(struct spi_flash * flash, u32_t offset)
+uint32_t spiflash_read_common(struct spi_flash * flash, uint32_t offset)
 {
 	/* size: 4MB base: 0x200_0000 */
 	return offset;
 }
 
-int spiflash_read_data_xip(struct spi_flash *flash, u32_t offset,
-		u32_t * buf, u32_t dump_byte, READ_CMD_TYPE_E type)
+int spiflash_read_data_xip(struct spi_flash *flash, uint32_t offset,
+		uint32_t * buf, uint32_t dump_byte, READ_CMD_TYPE_E type)
 {
-	u8_t cmd;
-	u32_t off_cmd;
+	uint8_t cmd;
+	uint32_t off_cmd;
 
 
 	switch (type) {
@@ -1152,19 +1152,19 @@ int spiflash_read_data_xip(struct spi_flash *flash, u32_t offset,
 	}
 
 	off_cmd = offset << 8 | cmd;
-	spiflash_set_xip_cmd(flash, (const u8_t *)(&off_cmd), dump_byte);
+	spiflash_set_xip_cmd(flash, (const uint8_t *)(&off_cmd), dump_byte);
 	*buf = spiflash_read_common(flash, offset);
 
 	return 0;
 }
 
-int spiflash_read_data_noxip(struct spi_flash *flash, u32_t address,
-		u32_t * buf, u32_t buf_size, READ_CMD_TYPE_E type)
+int spiflash_read_data_noxip(struct spi_flash *flash, uint32_t address,
+		uint32_t * buf, uint32_t buf_size, READ_CMD_TYPE_E type)
 {
-	u8_t cmd[1] = { 0 };
-	u32_t pbuf_size = 0;
-	u8_t *pbuf = NULL;
-	u32_t block_size = 8;
+	uint8_t cmd[1] = { 0 };
+	uint32_t pbuf_size = 0;
+	uint8_t *pbuf = NULL;
+	uint32_t block_size = 8;
 
 	switch (type) {
 		case READ_SPI:
@@ -1203,7 +1203,7 @@ int spiflash_read_data_noxip(struct spi_flash *flash, u32_t address,
 			return -1;
 	}
 
-	pbuf = (u8_t *)buf;
+	pbuf = (uint8_t *)buf;
 	pbuf_size = buf_size;
 	while (pbuf_size > block_size) {
 		spiflash_cmd_read(flash, cmd, 1, address, pbuf, block_size);
@@ -1216,17 +1216,17 @@ int spiflash_read_data_noxip(struct spi_flash *flash, u32_t address,
 	return 0;
 }
 
-static int spiflash_set_encrypt(u32_t op)
+static int spiflash_set_encrypt(uint32_t op)
 {
 	sfcdrv_setcmdencryptcfgreg(op);
 	return 0;
 }
 
-static int spiflash_change_4io(struct spi_flash *flash, u32_t op)
+static int spiflash_change_4io(struct spi_flash *flash, uint32_t op)
 {
-	u32_t dout = 0;
-	u8_t status1 = 0, status2 = 0;
-	u8_t cmd = 0;
+	uint32_t dout = 0;
+	uint8_t status1 = 0, status2 = 0;
+	uint8_t cmd = 0;
 	int ret = 0;
 
 	spiflash_get_status(flash, &status1, &status2);
@@ -1250,8 +1250,8 @@ static int spiflash_change_4io(struct spi_flash *flash, u32_t op)
 static int spiflash_enter_qpi(struct spi_flash *flash)
 {
 	int para = 0;
-	u8_t cmd = 0;
-	u8_t dummy_clocks = flash->dummy_bytes;
+	uint8_t cmd = 0;
+	uint8_t dummy_clocks = flash->dummy_bytes;
 
 	spiflash_change_4io(flash, TRUE);
 
@@ -1280,7 +1280,7 @@ static int spiflash_enter_qpi(struct spi_flash *flash)
 
 static int spiflash_exit_qpi(struct spi_flash *flash)
 {
-	u8_t cmd = 0;
+	uint8_t cmd = 0;
 	spiflash_change_4io(flash, FALSE);
 	cmd = CMD_EXIT_QPI;
 	spiflash_cmd_write(flash, &cmd, 1, NULL, 0);
@@ -1288,7 +1288,7 @@ static int spiflash_exit_qpi(struct spi_flash *flash)
 	return 0;
 }
 
-static int spiflash_set_qpi(struct spi_flash *flash, u32_t op)
+static int spiflash_set_qpi(struct spi_flash *flash, uint32_t op)
 {
 	if (TRUE == op) {
 		return spiflash_enter_qpi(flash);
@@ -1297,8 +1297,8 @@ static int spiflash_set_qpi(struct spi_flash *flash, u32_t op)
 	}
 }
 
-static int spiflash_read(struct spi_flash *flash, u32_t offset,
-		u32_t *buf, u32_t len, READ_CMD_TYPE_E type)
+static int spiflash_read(struct spi_flash *flash, uint32_t offset,
+		uint32_t *buf, uint32_t len, READ_CMD_TYPE_E type)
 {
 
 	unsigned int key;
@@ -1306,13 +1306,13 @@ static int spiflash_read(struct spi_flash *flash, u32_t offset,
 
 #ifndef CONFIG_W25_READONLY
 
-	u8_t dump_byte = 1;
-	u32_t read_char = 0;
+	uint8_t dump_byte = 1;
+	uint32_t read_char = 0;
 
 	/* modify for xip-sfc */
 	key = irq_lock_primask();
 
-	ret = spiflash_read_data_xip(flash, offset, (u32_t *) &read_char,
+	ret = spiflash_read_data_xip(flash, offset, (uint32_t *) &read_char,
 				     dump_byte, type);
 	irq_unlock_primask(key);
 
@@ -1347,7 +1347,7 @@ __ramfunc static void spiflash_enter_xip(void)
 	sci_write32(SFC_TYPE_BUF2, 0x00000000);
 }
 
-__ramfunc void spiflash_select_xip(u32_t op)
+__ramfunc void spiflash_select_xip(uint32_t op)
 {
 	if (op == TRUE) {
 		spiflash_enter_xip();

--- a/uwp5/drivers/src/sfc/hal_sfc_phy.c
+++ b/uwp5/drivers/src/sfc/hal_sfc_phy.c
@@ -12,10 +12,10 @@
 #include <hal_sfc_hal.h>
 
 static SFC_REG_T *reg_sfc = (SFC_REG_T *) BASE_AON_SFC_CFG;
-u32_t cmd_buf_index = 0;
-u32_t read_buf_index = 7;
+uint32_t cmd_buf_index = 0;
+uint32_t read_buf_index = 7;
 
-void sfcdrv_setcmdencryptcfgreg(u32_t cmdmode)
+void sfcdrv_setcmdencryptcfgreg(uint32_t cmdmode)
 {
 	reg_sfc->cmd_cfg.mBits.encrypt_de_en = cmdmode;
 }
@@ -28,7 +28,7 @@ __ramfunc void sfcdrv_setcmdcfgreg(CMD_MODE_E cmdmode, BIT_MODE_E bitmode,
 	reg_sfc->cmd_cfg.mBits.sts_ini_addr_sel = iniAddSel;
 }
 
-volatile u32_t s_while_count1 = 0;
+volatile uint32_t s_while_count1 = 0;
 
 __ramfunc void sfcdrv_softreq(void)
 {
@@ -61,37 +61,37 @@ __ramfunc void sfcdrv_intclr(void)
 	reg_sfc->int_clr.mBits.int_clr = BIT(0);
 }
 
-u32_t sfcdrv_getstatus(void)
+uint32_t sfcdrv_getstatus(void)
 {
 	return reg_sfc->status.dwValue;
 }
 
-void sfcdrv_cstimingcfg(u32_t value)
+void sfcdrv_cstimingcfg(uint32_t value)
 {
 	reg_sfc->cs_timing_cfg.dwValue = value;
 }
 
-void sfcdrv_rdtimingcfg(u32_t value)
+void sfcdrv_rdtimingcfg(uint32_t value)
 {
 	reg_sfc->rd_timing_cfg.dwValue = value;
 }
 
-__ramfunc void sfcdrv_clkcfg(u32_t value)
+__ramfunc void sfcdrv_clkcfg(uint32_t value)
 {
 	reg_sfc->clk_cfg.dwValue = value;
 }
 
-void sfcdrv_cscfg(u32_t value)
+void sfcdrv_cscfg(uint32_t value)
 {
 	reg_sfc->cs_cfg.dwValue = 0;
 }
 
-void sfcdrv_endiancfg(u32_t value)
+void sfcdrv_endiancfg(uint32_t value)
 {
 	reg_sfc->endian_cfg.dwValue = value;
 }
 
-__ramfunc void sfcdrv_setcmdbuf(CMD_BUF_INDEX_E index, u32_t value)
+__ramfunc void sfcdrv_setcmdbuf(CMD_BUF_INDEX_E index, uint32_t value)
 {
 	switch (index) {
 	case CMD_BUF_0:
@@ -146,19 +146,19 @@ __ramfunc void sfcdrv_setcmdbuf(CMD_BUF_INDEX_E index, u32_t value)
 	}
 }
 
-void sfcdrv_setcmdbufex(CMD_BUF_INDEX_E index, const u8_t *buf, u32_t count)
+void sfcdrv_setcmdbufex(CMD_BUF_INDEX_E index, const uint8_t *buf, uint32_t count)
 {
 	SFC_CMD_BUF0_U *cmd_buf;
 
 	cmd_buf =
-	    (SFC_CMD_BUF0_U *) ((u32_t) & reg_sfc->cmd_buf0 +
+	    (SFC_CMD_BUF0_U *) ((uint32_t) & reg_sfc->cmd_buf0 +
 				index * sizeof(SFC_CMD_BUF0_U));
-	memcpy((u8_t *) & cmd_buf->dwValue, buf, count);
+	memcpy((uint8_t *) & cmd_buf->dwValue, buf, count);
 }
 
-__ramfunc u32_t sfcdrv_getcmdbuf(CMD_BUF_INDEX_E index)
+__ramfunc uint32_t sfcdrv_getcmdbuf(CMD_BUF_INDEX_E index)
 {
-	u32_t value = 0;
+	uint32_t value = 0;
 
 	switch (index) {
 	case CMD_BUF_0:
@@ -326,9 +326,9 @@ void sfcdrv_setinitaddr(INI_ADD_SEL_E start_addr)
 	reg_sfc->cmd_cfg.mBits.sts_ini_addr_sel = start_addr;
 }
 
-__ramfunc u32_t sfcdrv_getinitaddr(void)
+__ramfunc uint32_t sfcdrv_getinitaddr(void)
 {
-	u32_t start_addr = 0;
+	uint32_t start_addr = 0;
 
 	start_addr = reg_sfc->cmd_cfg.mBits.sts_ini_addr_sel;
 
@@ -362,7 +362,7 @@ void sfcdrv_waitcmddone(void)
 	};
 }
 
-__ramfunc void sfcdrv_setcmddata(SFC_CMD_DES_T *cmd_des_ptr, u32_t cmd_flag)
+__ramfunc void sfcdrv_setcmddata(SFC_CMD_DES_T *cmd_des_ptr, uint32_t cmd_flag)
 {
 	if (cmd_flag == SPI_CMD_DATA_BEGIN) {
 		sfcdrv_cmdbufclr();
@@ -386,7 +386,7 @@ __ramfunc void sfcdrv_setcmddata(SFC_CMD_DES_T *cmd_des_ptr, u32_t cmd_flag)
 	}
 }
 
-__ramfunc void sfcdrv_setreadbuf(SFC_CMD_DES_T *cmd_des_ptr, u32_t cmd_flag)
+__ramfunc void sfcdrv_setreadbuf(SFC_CMD_DES_T *cmd_des_ptr, uint32_t cmd_flag)
 {
 	if (cmd_flag == SPI_CMD_DATA_BEGIN) {
 		sfcdrv_cmdbufclr();
@@ -410,34 +410,34 @@ __ramfunc void sfcdrv_setreadbuf(SFC_CMD_DES_T *cmd_des_ptr, u32_t cmd_flag)
 	}
 }
 
-void sfcdrv_getbuf(void *buffer, u32_t nbytes)
+void sfcdrv_getbuf(void *buffer, uint32_t nbytes)
 {
-	u32_t i = 0, cnt = 0, temp = 0;
-	u32_t _start_index = sfcdrv_getinitaddr();
-	u32_t data_in = 0;
-	u8_t *data_ptr8 = (u8_t *) (&data_in);
+	uint32_t i = 0, cnt = 0, temp = 0;
+	uint32_t _start_index = sfcdrv_getinitaddr();
+	uint32_t data_in = 0;
+	uint8_t *data_ptr8 = (uint8_t *) (&data_in);
 
 	for (cnt = _start_index; (cnt < read_buf_index) && (i < nbytes); cnt++) {
 		data_in = sfcdrv_getcmdbuf(cnt);
 		temp = (data_ptr8[0] << 24) | (data_ptr8[1] << 16) |
 		    (data_ptr8[2] << 8) | (data_ptr8[3] << 0);
 		if (nbytes - i < 4) {
-			memcpy((void *)((u32_t)buffer + i), &temp, nbytes - i);
+			memcpy((void *)((uint32_t)buffer + i), &temp, nbytes - i);
 			i += nbytes - i;
 		} else {
-			memcpy((void *)((u32_t)buffer + i), &temp, 4);
+			memcpy((void *)((uint32_t)buffer + i), &temp, 4);
 			i += 4;
 		}
 	}
 }
 
-__ramfunc void sfcdrv_getreadbuf(u32_t *buffer, u32_t word_cnt)
+__ramfunc void sfcdrv_getreadbuf(uint32_t *buffer, uint32_t word_cnt)
 {
-	u32_t i = 0;
-	u32_t cnt = 0;
-	u32_t _start_index = sfcdrv_getinitaddr();
-	u32_t data_in = 0;
-	u8_t *data_ptr8 = (u8_t *) (&data_in);
+	uint32_t i = 0;
+	uint32_t cnt = 0;
+	uint32_t _start_index = sfcdrv_getinitaddr();
+	uint32_t data_in = 0;
+	uint8_t *data_ptr8 = (uint8_t *) (&data_in);
 
 	for (cnt = _start_index; (cnt < read_buf_index) && (i < word_cnt);
 	     cnt++) {
@@ -455,12 +455,12 @@ __ramfunc void sfcdrv_resetallbuf(void)
 	read_buf_index = sfcdrv_getinitaddr();
 }
 
-__ramfunc void sfcdrv_intcfg(u32_t op)
+__ramfunc void sfcdrv_intcfg(uint32_t op)
 {
 	if (op == TRUE) {
-		*((volatile u32_t *)SFC_IEN) = 0xFF;
+		*((volatile uint32_t *)SFC_IEN) = 0xFF;
 	} else {
-		*((volatile u32_t *)SFC_IEN) = 0x00;
+		*((volatile uint32_t *)SFC_IEN) = 0x00;
 	}
 }
 
@@ -473,7 +473,7 @@ __ramfunc void sfcdrv_req(void)
 	while (!(SFC_IDLE_STATUS & sfcdrv_getstatus())) {
 	};
 #else
-	while (0 == (*((volatile u32_t *)SFC_INT_RAW))) {
+	while (0 == (*((volatile uint32_t *)SFC_INT_RAW))) {
 	};
 #endif
 }

--- a/uwp5/drivers/src/sipc/sblock.h
+++ b/uwp5/drivers/src/sipc/sblock.h
@@ -78,27 +78,27 @@ extern "C" {
 #define BT_RX_BLOCK_NUM   5
 
 struct sblock_blks {
-	u32_t		addr; /*phy address*/
-	u32_t		length;
+	uint32_t		addr; /*phy address*/
+	uint32_t		length;
 };
 
 /* ring block header */
 struct sblock_ring_header {
 	/* get|send-block info */
-	u32_t		txblk_addr;
-	u32_t		txblk_count;
-	u32_t		txblk_size;
-	u32_t		txblk_blks;
-	u32_t		txblk_rdptr;
-	u32_t		txblk_wrptr;
+	uint32_t		txblk_addr;
+	uint32_t		txblk_count;
+	uint32_t		txblk_size;
+	uint32_t		txblk_blks;
+	uint32_t		txblk_rdptr;
+	uint32_t		txblk_wrptr;
 
 	/* release|recv-block info */
-	u32_t		rxblk_addr;
-	u32_t		rxblk_count;
-	u32_t		rxblk_size;
-	u32_t		rxblk_blks;
-	u32_t		rxblk_rdptr;
-	u32_t		rxblk_wrptr;
+	uint32_t		rxblk_addr;
+	uint32_t		rxblk_count;
+	uint32_t		rxblk_size;
+	uint32_t		rxblk_blks;
+	uint32_t		rxblk_rdptr;
+	uint32_t		rxblk_wrptr;
 };
 
 struct sblock_header {
@@ -126,18 +126,18 @@ struct sblock_ring {
 };
 
 struct sblock_mgr {
-	u8_t			dst;
-	u8_t			channel;
-	u32_t		state;
+	uint8_t			dst;
+	uint8_t			channel;
+	uint32_t		state;
 
 	void			*smem_virt;
-	u32_t		smem_addr;
-	u32_t		smem_size;
+	uint32_t		smem_addr;
+	uint32_t		smem_size;
 
-	u32_t		txblksz;
-	u32_t		rxblksz;
-	u32_t		txblknum;
-	u32_t		rxblknum;
+	uint32_t		txblksz;
+	uint32_t		rxblksz;
+	uint32_t		txblknum;
+	uint32_t		rxblknum;
 
 	struct sblock_ring	ring;
 
@@ -153,33 +153,33 @@ struct sblock_mgr {
 
 #define SBLOCK_ALIGN_BYTES (4)
 
-static inline u32_t sblock_get_index(u32_t x, u32_t y)
+static inline uint32_t sblock_get_index(uint32_t x, uint32_t y)
 {
 	return (x / y);
 }
 
-static inline u32_t sblock_get_ringpos(u32_t x, u32_t y)
+static inline uint32_t sblock_get_ringpos(uint32_t x, uint32_t y)
 {
 	return is_power_of_2(y) ? (x & (y - 1)) : (x % y);
 }
 
-int sblock_create(u8_t dst, u8_t channel,
-		u32_t txblocknum, u32_t txblocksize,
-		u32_t rxblocknum, u32_t rxblocksize);
-int sblock_release(u8_t dst, u8_t channel, struct sblock *blk);
-int sblock_get_free_count(u8_t dst, u8_t channel);
-int sblock_get_arrived_count(u8_t dst, u8_t channel);
-int sblock_receive(u8_t dst, u8_t channel, struct sblock *blk, int timeout);
-int sblock_send_finish(u8_t dst, u8_t channel);
-int sblock_send(u8_t dst, u8_t channel, u8_t prio, struct sblock *blk);
-int sblock_send_prepare(u8_t dst, u8_t channel, u8_t prio, struct sblock *blk);
-int sblock_get(u8_t dst, u8_t channel, struct sblock *blk, int timeout);
-void sblock_put(u8_t dst, u8_t channel, struct sblock *blk);
-int sblock_register_notifier(u8_t dst, u8_t channel,
+int sblock_create(uint8_t dst, uint8_t channel,
+		uint32_t txblocknum, uint32_t txblocksize,
+		uint32_t rxblocknum, uint32_t rxblocksize);
+int sblock_release(uint8_t dst, uint8_t channel, struct sblock *blk);
+int sblock_get_free_count(uint8_t dst, uint8_t channel);
+int sblock_get_arrived_count(uint8_t dst, uint8_t channel);
+int sblock_receive(uint8_t dst, uint8_t channel, struct sblock *blk, int timeout);
+int sblock_send_finish(uint8_t dst, uint8_t channel);
+int sblock_send(uint8_t dst, uint8_t channel, uint8_t prio, struct sblock *blk);
+int sblock_send_prepare(uint8_t dst, uint8_t channel, uint8_t prio, struct sblock *blk);
+int sblock_get(uint8_t dst, uint8_t channel, struct sblock *blk, int timeout);
+void sblock_put(uint8_t dst, uint8_t channel, struct sblock *blk);
+int sblock_register_notifier(uint8_t dst, uint8_t channel,
 		void (*handler)(int event, void *data), void *data);
-int sblock_register_callback(u8_t channel,
+int sblock_register_callback(uint8_t channel,
 		void (*callback)(int ch));
-int sblock_unregister_callback(u8_t channel);
-int sblock_state(u8_t channel);
+int sblock_unregister_callback(uint8_t channel);
+int sblock_state(uint8_t channel);
 
 #endif

--- a/uwp5/drivers/src/sipc/sipc.c
+++ b/uwp5/drivers/src/sipc/sipc.c
@@ -16,7 +16,7 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 #include "sipc.h"
 #include "sipc_priv.h"
 
-extern int smsg_init(u32_t dst, u32_t smsg_base);
+extern int smsg_init(uint32_t dst, uint32_t smsg_base);
 static int sipc_init(struct device *arg)
 {
 	int ret;

--- a/uwp5/drivers/src/sipc/sipc.h
+++ b/uwp5/drivers/src/sipc/sipc.h
@@ -32,10 +32,10 @@ extern "C" {
 
 	/* share-mem ring buffer short message */
 	struct smsg {
-		u8_t		channel;	/* channel index */
-		u8_t		type;		/* msg type */
-		u16_t		flag;		/* msg flag */
-		u32_t		value;		/* msg value */
+		uint8_t		channel;	/* channel index */
+		uint8_t		type;		/* msg type */
+		uint16_t		flag;		/* msg flag */
+		uint32_t		value;		/* msg value */
 	};
 
 	/* smsg channel definition */
@@ -101,7 +101,7 @@ extern "C" {
  * @timeout: milliseconds, 0 means no wait, -1 means unlimited
  * @return: 0 on success, <0 on failure
  */
-int smsg_ch_open(u8_t dst, u8_t channel, int prio, int timeout);
+int smsg_ch_open(uint8_t dst, uint8_t channel, int prio, int timeout);
 
 /**
  * smsg_ch_close -- close a channel for smsg
@@ -111,7 +111,7 @@ int smsg_ch_open(u8_t dst, u8_t channel, int prio, int timeout);
  * @timeout: milliseconds, 0 means no wait, -1 means unlimited
  * @return: 0 on success, <0 on failure
  */
-int smsg_ch_close(u8_t dst, u8_t channel, int prio, int timeout);
+int smsg_ch_close(uint8_t dst, uint8_t channel, int prio, int timeout);
 
 /**
  * smsg_send -- send smsg
@@ -121,8 +121,8 @@ int smsg_ch_close(u8_t dst, u8_t channel, int prio, int timeout);
  * @timeout: milliseconds, 0 means no wait, -1 means unlimited
  * @return: 0 on success, <0 on failure
  */
-int smsg_send(u8_t dst, u8_t prio, struct smsg *msg, int timeout);
-int smsg_send_irq(u8_t dst, struct smsg *msg);
+int smsg_send(uint8_t dst, uint8_t prio, struct smsg *msg, int timeout);
+int smsg_send_irq(uint8_t dst, struct smsg *msg);
 /**
  * smsg_recv -- poll and recv smsg
  *
@@ -131,13 +131,13 @@ int smsg_send_irq(u8_t dst, struct smsg *msg);
  * @timeout: milliseconds, 0 means no wait, -1 means unlimited
  * @return: 0 on success, <0 on failure
  */
-int smsg_recv(u8_t dst, struct smsg *msg, int timeout);
+int smsg_recv(uint8_t dst, struct smsg *msg, int timeout);
 
 void wakeup_smsg_task_all(struct k_sem *sem);
 
 /* quickly fill a smsg body */
-static inline void smsg_set(struct smsg *msg, u8_t channel,
-		u8_t type, uint16_t flag, u32_t value)
+static inline void smsg_set(struct smsg *msg, uint8_t channel,
+		uint8_t type, uint16_t flag, uint32_t value)
 {
 	msg->channel = channel;
 	msg->type = type;
@@ -146,7 +146,7 @@ static inline void smsg_set(struct smsg *msg, u8_t channel,
 }
 
 /* ack an open msg for modem recovery */
-static inline void smsg_open_ack(u8_t dst, uint16_t channel)
+static inline void smsg_open_ack(uint8_t dst, uint16_t channel)
 {
 	struct smsg mopen;
 
@@ -155,7 +155,7 @@ static inline void smsg_open_ack(u8_t dst, uint16_t channel)
 }
 
 /* ack an close msg for modem recovery */
-static inline void smsg_close_ack(u8_t dst, uint16_t channel)
+static inline void smsg_close_ack(uint8_t dst, uint16_t channel)
 {
 	struct smsg mclose;
 
@@ -167,10 +167,10 @@ static inline void smsg_close_ack(u8_t dst, uint16_t channel)
 /* sblock structure: addr is the uncached virtual address */
 struct sblock {
 	void		*addr;
-	u32_t	length;
+	uint32_t	length;
 #ifdef CONFIG_ZERO_COPY_SIPX
-	u16_t        index;
-	u16_t        offset;
+	uint16_t        index;
+	uint16_t        offset;
 #endif
 };
 
@@ -182,8 +182,8 @@ struct sblock {
 
 extern int sipc_probe(void);
 extern int wifi_irq_init(void);
-extern void sprd_wifi_irq_disable_num(u32_t num);
-extern void sprd_wifi_irq_enable_num(u32_t num);
+extern void sprd_wifi_irq_disable_num(uint32_t num);
+extern void sprd_wifi_irq_enable_num(uint32_t num);
 
 #ifdef __cplusplus
 }

--- a/uwp5/drivers/src/sipc/sipc_priv.h
+++ b/uwp5/drivers/src/sipc/sipc_priv.h
@@ -21,20 +21,20 @@ extern "C" {
 		struct k_mutex		rxlock;
 		struct k_mutex		txlock;
 
-		u32_t refs;
-		u32_t state;
+		uint32_t refs;
+		uint32_t state;
 
 		/* cached msgs for recv */
-		u32_t			wrptr;
-		u32_t			rdptr;
+		uint32_t			wrptr;
+		uint32_t			rdptr;
 		struct smsg		caches[SMSG_CACHE_NR];
 	};
 
 	struct smsg_queue_buf {
-		u32_t			addr;
-		u32_t			size;	/* must be 2^n */
-		u32_t			rdptr;
-		u32_t			wrptr;
+		uint32_t			addr;
+		uint32_t			size;	/* must be 2^n */
+		uint32_t			rdptr;
+		uint32_t			wrptr;
 	};
 
 	struct smsg_queue {
@@ -47,8 +47,8 @@ extern "C" {
 		/* smsg ring-buffer between AP/CP ipc */
 	struct smsg_ipc {
 		char			*name;
-		u8_t			dst;
-		u8_t			padding[3];
+		uint8_t			dst;
+		uint8_t			padding[3];
 
 		struct smsg_queue   queue[QUEUE_PRIO_MAX];
 
@@ -60,7 +60,7 @@ extern "C" {
 		/* sipc irq related */
 		int			irq;
 
-		u32_t		(*rxirq_status)(void);
+		uint32_t		(*rxirq_status)(void);
 		void		(*rxirq_clear)(void);
 		void		(*txirq_trigger)(void);
 
@@ -69,7 +69,7 @@ extern "C" {
 		k_tid_t			 pid;
 		struct k_sem    irq_sem;
 		/* lock for send-buffer */
-		u32_t            txpinlock;
+		uint32_t            txpinlock;
 		/* all fixed channels receivers */
 		struct smsg_channel	channels[SMSG_CH_NR];
 	};
@@ -80,12 +80,12 @@ extern "C" {
 #define CHAN_STATE_FREE		3
 
 	/* create/destroy smsg ipc between AP/CP */
-	struct smsg_ipc *smsg_ipc_create(u8_t dst);
-	int smsg_ipc_destroy(u8_t dst);
+	struct smsg_ipc *smsg_ipc_create(uint8_t dst);
+	int smsg_ipc_destroy(uint8_t dst);
 	int  smsg_suspend_init(void);
 
 	/* initialize smem pool for AP/CP */
-	int smem_init(u32_t addr, u32_t size);
+	int smem_init(uint32_t addr, uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/uwp5/drivers/src/sipc/smsg.c
+++ b/uwp5/drivers/src/sipc/smsg.c
@@ -55,7 +55,7 @@ static struct smsg_ipc smsg_ipcs[SIPC_ID_NR];
 #define SMSG_RXBUF_WRPTR	(SMSG_RINGHDR + 44)
 
 void sipc_init_smsg_queue_buf(struct smsg_queue_buf *buf,
-		u32_t size, u32_t addr, u32_t rdptr, u32_t wrptr)
+		uint32_t size, uint32_t addr, uint32_t rdptr, uint32_t wrptr)
 {
 	buf->size = size / sizeof(struct smsg);
 	buf->addr = addr;
@@ -63,7 +63,7 @@ void sipc_init_smsg_queue_buf(struct smsg_queue_buf *buf,
 	buf->wrptr = wrptr;
 }
 
-static struct smsg_ipc *smsg_set_addr(struct smsg_ipc *ipc, u32_t base)
+static struct smsg_ipc *smsg_set_addr(struct smsg_ipc *ipc, uint32_t base)
 {
 	sipc_init_smsg_queue_buf(&ipc->queue[QUEUE_PRIO_IRQ].tx_buf,
 			SMSG_IRQ_TXBUF_SIZE,
@@ -192,7 +192,7 @@ int smsg_msg_dispatch_thread(int argc, char *argv[])
 
 }
 
-int smsg_ipc_destroy(u8_t dst)
+int smsg_ipc_destroy(uint8_t dst)
 {
 	struct smsg_ipc *ipc = &smsg_ipcs[dst];
 
@@ -201,7 +201,7 @@ int smsg_ipc_destroy(u8_t dst)
 	return 0;
 }
 
-int smsg_ch_open(u8_t dst, u8_t channel, int prio, int timeout)
+int smsg_ch_open(uint8_t dst, uint8_t channel, int prio, int timeout)
 {
 	struct smsg_ipc *ipc = &smsg_ipcs[dst];
 	struct smsg_channel *ch;
@@ -241,7 +241,7 @@ int smsg_ch_open(u8_t dst, u8_t channel, int prio, int timeout)
 	return 0;
 }
 
-int smsg_ch_close(u8_t dst, u8_t channel, int prio, int timeout)
+int smsg_ch_close(uint8_t dst, uint8_t channel, int prio, int timeout)
 {
 	struct smsg_ipc *ipc = &smsg_ipcs[dst];
 	struct smsg_channel *ch = &ipc->channels[channel];
@@ -258,7 +258,7 @@ int smsg_ch_close(u8_t dst, u8_t channel, int prio, int timeout)
 	return 0;
 }
 
-int smsg_send_irq(u8_t dst, struct smsg *msg)
+int smsg_send_irq(uint8_t dst, struct smsg *msg)
 {
 	struct smsg_ipc *ipc = &smsg_ipcs[dst];
 	struct smsg_queue_buf *tx_buf;
@@ -297,12 +297,12 @@ send_failed:
 	return ret;
 }
 
-int smsg_send(u8_t dst, u8_t prio, struct smsg *msg, int timeout)
+int smsg_send(uint8_t dst, uint8_t prio, struct smsg *msg, int timeout)
 {
 	struct smsg_channel *ch;
 	struct smsg_queue_buf *tx_buf;
 	struct smsg_ipc *ipc = &smsg_ipcs[dst];
-	u32_t txpos;
+	uint32_t txpos;
 	int ret = 0;
 
 	ch = &ipc->channels[msg->channel];
@@ -370,7 +370,7 @@ static void smsg_irq_handler(void *arg)
 	irq_enable(NVIC_INT_GNSS2BTWF_IPI);
 }
 
-int smsg_init(u32_t dst, u32_t smsg_base)
+int smsg_init(uint32_t dst, uint32_t smsg_base)
 {
 	struct smsg_ipc *ipc = &smsg_ipcs[dst];
 

--- a/uwp5/drivers/src/sipc/uwp_irq_relay.c
+++ b/uwp5/drivers/src/sipc/uwp_irq_relay.c
@@ -34,40 +34,40 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 #define CEVA_IP_INT_CLEAR_ADDR (0x40246000+0x28)
 #define CEVA_IP_int_clear(clear_bit) { int temp = \
-	*((volatile u32_t *)CEVA_IP_INT_CLEAR_ADDR); \
-	temp |= clear_bit; *((volatile u32_t *)CEVA_IP_INT_CLEAR_ADDR) = temp; }
+	*((volatile uint32_t *)CEVA_IP_INT_CLEAR_ADDR); \
+	temp |= clear_bit; *((volatile uint32_t *)CEVA_IP_INT_CLEAR_ADDR) = temp; }
 
 #define CEVA_IP_int_MASK(bit) {int temp = \
-	*((volatile u32_t *)CEVA_IP_INT_CLEAR_ADDR); \
-	temp |= bit; *((volatile u32_t *)CEVA_IP_INT_CLEAR_ADDR) = temp; }
+	*((volatile uint32_t *)CEVA_IP_INT_CLEAR_ADDR); \
+	temp |= bit; *((volatile uint32_t *)CEVA_IP_INT_CLEAR_ADDR) = temp; }
 #define CEVA_IP_int_UNMASK(bit) {int temp = \
-	*((volatile u32_t *)CEVA_IP_INT_CLEAR_ADDR); \
-	temp &= ~bit; *((volatile u32_t *)CEVA_IP_INT_CLEAR_ADDR) = temp; }
+	*((volatile uint32_t *)CEVA_IP_INT_CLEAR_ADDR); \
+	temp &= ~bit; *((volatile uint32_t *)CEVA_IP_INT_CLEAR_ADDR) = temp; }
 
 
 #define HW_DEC_INT_CLEAR (0x40240000+0x304)
 #define HW_DEC_INT1_CLEAR (0x40240000+0x308)
 
 #define HW_DEC_int_clear(clear_bit) \
-{unsigned int temp = *((volatile u32_t *)HW_DEC_INT_CLEAR); \
+{unsigned int temp = *((volatile uint32_t *)HW_DEC_INT_CLEAR); \
 	temp |= clear_bit; \
-	*((volatile u32_t *)HW_DEC_INT_CLEAR) = temp; \
+	*((volatile uint32_t *)HW_DEC_INT_CLEAR) = temp; \
 	temp &= ~clear_bit; \
-	*((volatile u32_t *)HW_DEC_INT_CLEAR) = temp; }
+	*((volatile uint32_t *)HW_DEC_INT_CLEAR) = temp; }
 
 #define HW_DEC_int_clear_sts \
 {	unsigned int temp1; \
-	unsigned int temp = *((volatile u32_t *)HW_DEC_INT_CLEAR); \
+	unsigned int temp = *((volatile uint32_t *)HW_DEC_INT_CLEAR); \
 	temp1 = (temp >> 16)&0xff; \
-	*((volatile u32_t *)HW_DEC_INT_CLEAR) = temp | temp1; \
-	*((volatile u32_t *)HW_DEC_INT_CLEAR) = temp&(~0xff); }
+	*((volatile uint32_t *)HW_DEC_INT_CLEAR) = temp | temp1; \
+	*((volatile uint32_t *)HW_DEC_INT_CLEAR) = temp&(~0xff); }
 
 #define HW_DEC_int1_clear_sts \
 {	unsigned int temp1; \
-	unsigned int temp = *((volatile u32_t *)HW_DEC_INT1_CLEAR); \
+	unsigned int temp = *((volatile uint32_t *)HW_DEC_INT1_CLEAR); \
 	temp1 = (temp >> 16)&0xff; \
-	*((volatile u32_t *)HW_DEC_INT1_CLEAR) = temp | temp1; \
-	*((volatile u32_t *)HW_DEC_INT1_CLEAR) = temp&(~0xff); }
+	*((volatile uint32_t *)HW_DEC_INT1_CLEAR) = temp | temp1; \
+	*((volatile uint32_t *)HW_DEC_INT1_CLEAR) = temp&(~0xff); }
 
 #define  PKD_INTR_MASK          (1<<4)
 #define  AUX_TMR_INTR_MASK      (1<<5)
@@ -92,69 +92,69 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 #define ATOR_INTR2        (1<<2)
 
 #define SHARE_MEM_WATCH   (0x1EEF00)
-u16_t clear_bt_int(int irq_num)
+uint16_t clear_bt_int(int irq_num)
 {
-	u16_t tem=0;
+	uint16_t tem=0;
 	switch (irq_num) {
 	case NVIC_BT_MASKED_TIM_INTR0:
-		*((u16_t *)(SHARE_MEM_WATCH+0x0c)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0x0c));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x0c)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0x0c));
 		CEVA_IP_int_clear(TIM_INTRO_CLR); break;
 	case NVIC_BT_MASKED_TIM_INTR1:
-		*((u16_t *)(SHARE_MEM_WATCH+0x10)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0x10));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x10)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0x10));
 		CEVA_IP_int_clear(TIM_INTR1_CLR); break;
 	case NVIC_BT_MASKED_TIM_INTR2:
-		*((u16_t *)(SHARE_MEM_WATCH+0x14)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0x14));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x14)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0x14));
 		CEVA_IP_int_clear(TIM_INTR2_CLR); break;
 	case NVIC_BT_MASKED_TIM_INTR3:
-		*((u16_t *)(SHARE_MEM_WATCH+0x18)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0x18));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x18)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0x18));
 		CEVA_IP_int_clear(TIM_INTR3_CLR); break;
 	case NVIC_BT_MASKED_AUX_TMR_INTR:
-		*((u16_t *)(SHARE_MEM_WATCH+0x24)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0x24));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x24)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0x24));
 		CEVA_IP_int_clear(AUX_TMR_INTR); break;
 	case NVIC_BT_MASKED_PKA_INTR:
-		*((u16_t *)(SHARE_MEM_WATCH+0x20)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0x20));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x20)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0x20));
 		CEVA_IP_int_clear(PKA_INTR); break;
 	case NVIC_BT_MASKED_SYNC_DET_INTR:
-		*((u16_t *)(SHARE_MEM_WATCH+0x04)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0x04));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x04)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0x04));
 		CEVA_IP_int_clear(SYNC_DET_INTR); break;
 	case NVIC_BT_MASKED_PKD_RX_HDR:
-		*((u16_t *)(SHARE_MEM_WATCH+0x08)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0x08));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x08)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0x08));
 		CEVA_IP_int_clear(PKD_RX_HDR); break;
 	case NVIC_BT_MASKED_PKD_INTR:
-		*((u16_t *)(SHARE_MEM_WATCH+0x1c)) += 1;
-		tem =  *((u16_t *)(SHARE_MEM_WATCH+0x1c));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x1c)) += 1;
+		tem =  *((uint16_t *)(SHARE_MEM_WATCH+0x1c));
 		CEVA_IP_int_clear(PKD_INTR); break;
 	case NVIC_BT_MASKED_PAGE_TIMEOUT_INTR:
-		*((u16_t *)(SHARE_MEM_WATCH+0)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0));
+		*((uint16_t *)(SHARE_MEM_WATCH+0)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0));
 		CEVA_IP_int_MASK(PKD_NO_PKD_INTR_MASK); break;
 	case NVIC_BT_ACCELERATOR_INTR0:
-		*((u16_t *)(SHARE_MEM_WATCH+0x28)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0x28));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x28)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0x28));
 		HW_DEC_int_clear(ATOR_INTR0); break;
 	case NVIC_BT_ACCELERATOR_INTR1:
-		*((u16_t *)(SHARE_MEM_WATCH+0x2c)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0x2c));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x2c)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0x2c));
 		HW_DEC_int_clear(ATOR_INTR1); break;
 	case NVIC_BT_ACCELERATOR_INTR2:
-		*((u16_t *)(SHARE_MEM_WATCH+0x30)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0x30));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x30)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0x30));
 		HW_DEC_int_clear(ATOR_INTR2); break;
 	case NVIC_BT_ACCELERATOR_INTR3:
-		*((u16_t *)(SHARE_MEM_WATCH+0x34)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0x34));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x34)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0x34));
 		HW_DEC_int_clear_sts; break;
 	case NVIC_BT_ACCELERATOR_INTR4:
-		*((u16_t *)(SHARE_MEM_WATCH+0x38)) += 1;
-		tem = *((u16_t *)(SHARE_MEM_WATCH+0x38));
+		*((uint16_t *)(SHARE_MEM_WATCH+0x38)) += 1;
+		tem = *((uint16_t *)(SHARE_MEM_WATCH+0x38));
 		HW_DEC_int1_clear_sts; break;
 
     default:
@@ -210,7 +210,7 @@ static int bt_irq_handler(void *arg)
 {
 	struct smsg msg;
 	s32_t irq = (s32_t)arg;
-	u16_t tem;
+	uint16_t tem;
 	tem = clear_bt_int(irq);
 	smsg_set(&msg, SMSG_CH_IRQ_DIS, SMSG_TYPE_EVENT, tem, irq);
 	smsg_send_irq(SIPC_ID_AP, &msg);
@@ -270,7 +270,7 @@ int sprd_bt_irq_init(void)
 	return 0;
 }
 
-void sprd_wifi_irq_enable_num(u32_t num)
+void sprd_wifi_irq_enable_num(uint32_t num)
 {
 	LOG_INF("wifi irq enable %d\n", num);
 
@@ -287,7 +287,7 @@ void sprd_wifi_irq_enable_num(u32_t num)
 
 }
 
-void sprd_wifi_irq_disable_num(u32_t num)
+void sprd_wifi_irq_disable_num(uint32_t num)
 {
 	LOG_INF("wifi irq enable %d\n", num);
 	switch (num) {

--- a/uwp5/soc/cache.c
+++ b/uwp5/soc/cache.c
@@ -33,7 +33,7 @@ static CACHE_BLOCK_OP_T C_DCACHE_DEFAULT_BLOCK_CFG[] = {
 	{ BLOCK_7, 0x04900000, FALSE, FALSE },
 };
 
-static u32_t icache_bus_cfg_addr[] = {
+static uint32_t icache_bus_cfg_addr[] = {
 	REG_ICACHE_BUS_CFG0,
 	REG_ICACHE_BUS_CFG1,
 	REG_ICACHE_BUS_CFG2,
@@ -44,7 +44,7 @@ static u32_t icache_bus_cfg_addr[] = {
 	REG_ICACHE_BUS_CFG7,
 };
 
-static u32_t dcache_bus_cfg_addr[] = {
+static uint32_t dcache_bus_cfg_addr[] = {
 	REG_DCACHE_BUS_CFG0,
 	REG_DCACHE_BUS_CFG1,
 	REG_DCACHE_BUS_CFG2,
@@ -55,7 +55,7 @@ static u32_t dcache_bus_cfg_addr[] = {
 	REG_DCACHE_BUS_CFG7,
 };
 
-static u32_t icache_bus_remap_addr[] = {
+static uint32_t icache_bus_remap_addr[] = {
 	REG_ICACHE_BUS_REMAP0,
 	REG_ICACHE_BUS_REMAP1,
 	REG_ICACHE_BUS_REMAP2,
@@ -66,7 +66,7 @@ static u32_t icache_bus_remap_addr[] = {
 	REG_ICACHE_BUS_REMAP7,
 };
 
-static u32_t dcache_bus_remap_addr[] = {
+static uint32_t dcache_bus_remap_addr[] = {
 	REG_DCACHE_BUS_REMAP0,
 	REG_DCACHE_BUS_REMAP1,
 	REG_DCACHE_BUS_REMAP2,
@@ -77,10 +77,10 @@ static u32_t dcache_bus_remap_addr[] = {
 	REG_DCACHE_BUS_REMAP7,
 };
 
-u32_t *cache_bus_cfg_addr = &dcache_bus_cfg_addr[0];
-u32_t *cache_bus_remap_addr = &dcache_bus_remap_addr[0];
+uint32_t *cache_bus_cfg_addr = &dcache_bus_cfg_addr[0];
+uint32_t *cache_bus_remap_addr = &dcache_bus_remap_addr[0];
 CACHE_BLOCK_OP_T *block_cfg = NULL;
-u32_t CACHE_BUS_STS0, CACHE_CFG0, CACHE_CMD_CFG0,
+uint32_t CACHE_BUS_STS0, CACHE_CFG0, CACHE_CMD_CFG0,
       CACHE_CMD_CFG1, CACHE_CMD_CFG2, CACHE_INT_CLR,
       CACHE_INT_RAW_STS, CACHE_INT_EN, CACHE_INT_MSK_STS,
       CACHE_WRITE_MISS_CNT, CACHE_WRITE_HIT_CNT, CACHE_READ_MISS_CNT,
@@ -111,7 +111,7 @@ void icache_disable_block(CACHE_BLOCK_E block_num)
 
 void dcache_enable_block(CACHE_BLOCK_E block_num)
 {
-	u32_t t = 0;
+	uint32_t t = 0;
 
 	sci_write32(REG_DCACHE_CMD_CFG0, block_cfg[block_num].start);
 	sci_write32(REG_DCACHE_CMD_CFG1, block_cfg[block_num + 1].start);
@@ -128,7 +128,7 @@ void dcache_enable_block(CACHE_BLOCK_E block_num)
 
 void dcache_disable_block(CACHE_BLOCK_E block_num)
 {
-	u32_t t = 0;
+	uint32_t t = 0;
 
 	sci_write32(REG_DCACHE_CMD_CFG0,
 			C_DCACHE_DEFAULT_BLOCK_CFG[block_num].start);
@@ -147,23 +147,23 @@ void dcache_disable_block(CACHE_BLOCK_E block_num)
 
 }
 
-static inline void cache_cmd_entry(u32_t addr)
+static inline void cache_cmd_entry(uint32_t addr)
 {
 	sci_write32(CACHE_CMD_CFG0, addr & CACHE_STR_ADDR_MASK);
 }
 
-static inline void cache_cmd_range(u32_t start, u32_t end)
+static inline void cache_cmd_range(uint32_t start, uint32_t end)
 {
 	sci_write32(CACHE_CMD_CFG0, start & CACHE_STR_ADDR_MASK);
 	sci_write32(CACHE_CMD_CFG1, end & CACHE_END_ADDR_MASK);
 }
 
-u32_t cache_check(CACHE_CMD_T *cmd)
+uint32_t cache_check(CACHE_CMD_T *cmd)
 {
-	u32_t ret = 0;
-	u32_t size = BLOCK_MAX;
-	u32_t area_masked = C_AREA_MASK & cmd->type;
-	u32_t cache_op_masked = C_OP_MASK & cmd->type;
+	uint32_t ret = 0;
+	uint32_t size = BLOCK_MAX;
+	uint32_t area_masked = C_AREA_MASK & cmd->type;
+	uint32_t cache_op_masked = C_OP_MASK & cmd->type;
 
 	switch (area_masked) {
 	case C_ALLAREA:
@@ -230,10 +230,10 @@ u32_t cache_check(CACHE_CMD_T *cmd)
 	return ret;
 }
 
-u32_t cache_execmd(CACHE_CMD_T *cmd, u32_t force)
+uint32_t cache_execmd(CACHE_CMD_T *cmd, uint32_t force)
 {
-	u32_t value = CACHE_CMD_ISSUE_START;
-	u32_t ret = 0;
+	uint32_t value = CACHE_CMD_ISSUE_START;
+	uint32_t ret = 0;
 
 
 	if (!force) {
@@ -297,9 +297,9 @@ u32_t cache_execmd(CACHE_CMD_T *cmd, u32_t force)
 	return ret;
 }
 
-u32_t cache_enableblock(CACHE_BLOCK_OP_T *pblock, cache_op op)
+uint32_t cache_enableblock(CACHE_BLOCK_OP_T *pblock, cache_op op)
 {
-	u32_t enable_bit = pblock->id - (u32_t) (BLOCK_0);
+	uint32_t enable_bit = pblock->id - (uint32_t) (BLOCK_0);
 
 	if (C_WRITE == op) {
 		if (pblock->en_cache) {
@@ -328,9 +328,9 @@ u32_t cache_enableblock(CACHE_BLOCK_OP_T *pblock, cache_op op)
 	}
 }
 
-u32_t cache_protblock(CACHE_BLOCK_OP_T *pblock, cache_op op)
+uint32_t cache_protblock(CACHE_BLOCK_OP_T *pblock, cache_op op)
 {
-	u32_t enable_bit = pblock->id - (u32_t) (BLOCK_0) +16;
+	uint32_t enable_bit = pblock->id - (uint32_t) (BLOCK_0) +16;
 
 	if (C_WRITE == op) {
 		if (pblock->en_prot) {
@@ -355,7 +355,7 @@ void cache_configaddr(CACHE_BLOCK_OP_T *pblock)
 		return;
 	}
 	pblock->start = pblock->start & BLOCK_1_START_ADDR_MASK;
-	sci_write32(cache_bus_cfg_addr[pblock->id - (u32_t) BLOCK_0],
+	sci_write32(cache_bus_cfg_addr[pblock->id - (uint32_t) BLOCK_0],
 			pblock->start);
 }
 
@@ -366,9 +366,9 @@ void cache_size_sel(CACHE_SIZE_SEL_E cache_size)
 		 & CACHE_SIZE_SEL_MASK, CACHE_CFG0);
 }
 
-u32_t cache_execmd_invalid_clean_all(CACHE_CMD_T *cmd, u32_t force)
+uint32_t cache_execmd_invalid_clean_all(CACHE_CMD_T *cmd, uint32_t force)
 {
-	u32_t value = CACHE_CMD_ISSUE_START;
+	uint32_t value = CACHE_CMD_ISSUE_START;
 
 	set_bits(CACHE_CMD_IRQ_CLR, CACHE_INT_CLR);
 	if (C_CLEAN_ALL == cmd->type) {
@@ -451,7 +451,7 @@ void dcache_set_reg(void)
 	block_cfg = &C_DCACHE_DEFAULT_BLOCK_CFG[0];
 }
 
-void cache_execusecfg(CACHE_BLOCK_OP_T *pcfg, u32_t size)
+void cache_execusecfg(CACHE_BLOCK_OP_T *pcfg, uint32_t size)
 {
 	int32_t i;
 
@@ -549,7 +549,7 @@ void cache_invalid_range_hal(uint8_t *begin, uint32_t data_len)
 
 void icache_phy_init(CACHE_SIZE_SEL_E icache_size)
 {
-	u32_t i;
+	uint32_t i;
 	CACHE_CMD_T cmd;
 
 	cmd.type = C_INVALID_ALL;
@@ -566,7 +566,7 @@ void icache_phy_init(CACHE_SIZE_SEL_E icache_size)
 
 void dcache_phy_init(CACHE_SIZE_SEL_E dcache_size)
 {
-	u32_t i;
+	uint32_t i;
 	CACHE_CMD_T cmd;
 
 	cmd.type = C_INVALID_ALL;

--- a/uwp5/soc/gnss.c
+++ b/uwp5/soc/gnss.c
@@ -414,15 +414,15 @@ typedef enum {
 
 #define DELAY(time)									 \
 	do {										 \
-		u32_t delay_time;							 \
+		uint32_t delay_time;							 \
 		for (delay_time = 0; delay_time < (time * RF_SYS_CLK * 2); delay_time++) \
 		{}									 \
 	} while (0)
 
 typedef struct {
-	u32_t divn;
-	u32_t divfrach;
-	u32_t divfracl;
+	uint32_t divn;
+	uint32_t divfrach;
+	uint32_t divfracl;
 } LO_FREQ_STRC;
 #define RF_LO_FREQ_TABLE_CRYSTAL_OFFSET     5
 const LO_FREQ_STRC g_RF_LO_FREQ[10] =
@@ -440,9 +440,9 @@ const LO_FREQ_STRC g_RF_LO_FREQ[10] =
 	{ 0x52, 0x5, 0xD70A }
 };
 
-void RF_readCtlReg(u32_t addr, u32_t *data)
+void RF_readCtlReg(uint32_t addr, uint32_t *data)
 {
-	u32_t reg_data = 0;
+	uint32_t reg_data = 0;
 
 	reg_data = ((addr & 0x7FFF) << 16) | 0x80000000;
 	sci_write32(RF_CTL_MASTER_BASE, reg_data);
@@ -453,9 +453,9 @@ void RF_readCtlReg(u32_t addr, u32_t *data)
 	DELAY(1);
 }
 
-void RF_writeCtlReg(u32_t addr, u32_t data)
+void RF_writeCtlReg(uint32_t addr, uint32_t data)
 {
-	u32_t reg_data = 0;
+	uint32_t reg_data = 0;
 
 	reg_data = ((addr & 0X7FFF) << 16) | (data & 0xFFFF);
 	sci_write32(RF_CTL_MASTER_BASE, reg_data);
@@ -472,7 +472,7 @@ void RF_softReset(void)
 
 void RF_setInterface(void)
 {
-	u32_t sel;
+	uint32_t sel;
 
 	sel = 1;
 
@@ -485,16 +485,16 @@ void RF_setInterface(void)
 
 void RF_setSWCtrlFSMState(void)
 {
-	u32_t data;
+	uint32_t data;
 
 	RF_readCtlReg(GE_MODE_MUX, &data);
 	data &= ~GE_MODE_CTRL_SEL;
 	RF_writeCtlReg(GE_MODE_MUX, data);
 }
 
-void RF_switchState(u32_t state)
+void RF_switchState(uint32_t state)
 {
-	u32_t data;
+	uint32_t data;
 
 	RF_readCtlReg(RF_HW_RST_CTRL0, &data);
 	data &= 0xFFFFE1FF;
@@ -504,7 +504,7 @@ void RF_switchState(u32_t state)
 
 void RF_setSXFreqDivRatio(LO_FREQ_STRC regs_cfg)
 {
-	u32_t data;
+	uint32_t data;
 
 	RF_readCtlReg(GE_SX_DIVN_CTRL0, &data);
 	data &= 0xFFFF00FF;
@@ -522,9 +522,9 @@ void RF_setSXFreqDivRatio(LO_FREQ_STRC regs_cfg)
 	RF_writeCtlReg(GE_SX_DIVNFRAC_CTRLL, data);
 }
 
-void RF_setGNSSMode(u32_t sys_indx)
+void RF_setGNSSMode(uint32_t sys_indx)
 {
-	u32_t data;
+	uint32_t data;
 
 	RF_readCtlReg(PS_GE_RX_CTRL3, &data);
 	data &= 0xFFFF1FFF;
@@ -533,9 +533,9 @@ void RF_setGNSSMode(u32_t sys_indx)
 
 }
 
-void RF_setADCclk(u32_t divRatio1, u32_t divRatio2)
+void RF_setADCclk(uint32_t divRatio1, uint32_t divRatio2)
 {
-	u32_t data;
+	uint32_t data;
 
 	RF_readCtlReg(PS_GE_CLK_GEN_CTRL1, &data);
 	data &= 0xffffc3ff;
@@ -559,9 +559,9 @@ void RF_setADCclk(u32_t divRatio1, u32_t divRatio2)
 	RF_writeCtlReg(GE_CLK_GATE_CTRL, data);
 }
 
-void RF_setPPclk(u32_t divRatio1, u32_t divRatio2)
+void RF_setPPclk(uint32_t divRatio1, uint32_t divRatio2)
 {
-	u32_t data;
+	uint32_t data;
 
 	RF_readCtlReg(PS_GE_CLK_GEN_CTRL2, &data);
 	data &= 0xfffff87f;
@@ -585,15 +585,15 @@ void RF_setPPclk(u32_t divRatio1, u32_t divRatio2)
 	RF_writeCtlReg(GE_CLK_GATE_CTRL, data);
 }
 
-void RF_setADCEnable(u32_t divRatio1, u32_t divRatio2)
+void RF_setADCEnable(uint32_t divRatio1, uint32_t divRatio2)
 {
 	RF_setADCclk(divRatio1, divRatio2);
 	APB_ADC_ENABLE();
 }
 
-void RF_setPGAGain(u32_t gain)
+void RF_setPGAGain(uint32_t gain)
 {
-	u32_t data;
+	uint32_t data;
 
 	RF_readCtlReg(GE_RX_GAIN_CTRL0, &data);
 	data &= 0xffff0fff;
@@ -601,9 +601,9 @@ void RF_setPGAGain(u32_t gain)
 	RF_writeCtlReg(GE_RX_GAIN_CTRL0, data);
 }
 
-void RF_Control(s16_t RF_Mode)
+void RF_Control(int16_t RF_Mode)
 {
-	u32_t data_tmp;
+	uint32_t data_tmp;
 
 	sci_reg_or(BIT_AON_APB_GNSS_RF_CTRL_GNSS_RF_CTRL_ADDR, BIT(1));
 
@@ -652,7 +652,7 @@ void RF_Control(s16_t RF_Mode)
 	APB_GNSS_POWER_ON();
 	DELAY(1);
 
-	u32_t gnss_pwron_finish_flag = 0;
+	uint32_t gnss_pwron_finish_flag = 0;
 	while (!gnss_pwron_finish_flag) {
 		gnss_pwron_finish_flag  = APB_GET_GNSS_POWERON_FINISH();
 		DELAY(1);
@@ -671,7 +671,7 @@ void RF_Control(s16_t RF_Mode)
 
 void RF_CFG(void)
 {
-	s16_t rf_mode = 0;
+	int16_t rf_mode = 0;
 
 	rf_mode = RF_GPS_BD_GLO_MODE;
 	RF_Control(rf_mode);
@@ -679,7 +679,7 @@ void RF_CFG(void)
 
 void BB_RESET(void)
 {
-	u32_t regValue = 0x0;
+	uint32_t regValue = 0x0;
 
 	regValue = sci_read32(SOFT_RST);
 	sci_write32(SOFT_RST, (regValue | 0x100000));


### PR DESCRIPTION
Since the use of custom integer types are removed from mainline zephyr,
let's also do the same here and switch to standard types.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>